### PR TITLE
Update package.xml

### DIFF
--- a/fflib/src/package.xml
+++ b/fflib/src/package.xml
@@ -7,7 +7,6 @@
         <members>fflib_SObjectDescribeTest</members>
         <members>fflib_SObjectDomain</members>
         <members>fflib_SObjectDomainTest</members>
-        <members>fflib_SObjectDomainTestCases</members>
         <members>fflib_SObjectSelector</members>
         <members>fflib_SObjectSelectorTest</members>
         <members>fflib_SObjectUnitOfWork</members>


### PR DESCRIPTION
Removed <members>fflib_SObjectDomainTestCases</members> which is not present in the repo and therefore prevents you deploying using the 'Deploy to Salesforce' link.
