### PR TITLE
Update fflib_SObjectSelectorTest.cls

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelectorTest.cls
+++ b/fflib/src/classes/fflib_SObjectSelectorTest.cls
@@ -40,7 +40,7 @@ private with sharing class fflib_SObjectSelectorTest
 		system.assert(fieldSet.contains('AnnualRevenue'));
 		if(UserInfo.isMultiCurrencyOrganization())
 			system.assert(fieldSet.contains('CurrencyIsoCode'));
-		system.assertEquals('myprefix.Name,myprefix.Id,myprefix.AccountNumber,myprefix.AnnualRevenue', selector.getRelatedFieldListString('myprefix'));
+		system.assertEquals('myprefix.AccountNumber,myprefix.AnnualRevenue,myprefix.Id,myprefix.Name', selector.getRelatedFieldListString('myprefix'));
 	}
 	
 	static testMethod void testGetSObjectName()
@@ -174,9 +174,9 @@ private with sharing class fflib_SObjectSelectorTest
 		System.assertEquals(false, selector.isEnforcingFLS());
 		System.assertEquals(true, selector.isEnforcingCRUD());
 		System.assertEquals(false, selector.isIncludeFieldSetFields());
-		System.assertEquals('Name,AccountNumber,Id,AnnualRevenue', selector.getFieldListBuilder().getStringValue());
-		System.assertEquals('Name,AccountNumber,Id,AnnualRevenue', selector.getFieldListString());
-		System.assertEquals('LookupField__r.Name,LookupField__r.AccountNumber,LookupField__r.Id,LookupField__r.AnnualRevenue', selector.getRelatedFieldListString('LookupField__r'));
+		System.assertEquals('AccountNumber,AnnualRevenue,Id,Name', selector.getFieldListBuilder().getStringValue());
+		System.assertEquals('AccountNumber,AnnualRevenue,Id,Name', selector.getFieldListString());
+		System.assertEquals('LookupField__r.AccountNumber,LookupField__r.AnnualRevenue,LookupField__r.Id,LookupField__r.Name', selector.getRelatedFieldListString('LookupField__r'));
 		System.assertEquals('Account', selector.getSObjectName());
 		System.assertEquals(Account.SObjectType, selector.getSObjectType2());
 	}
@@ -197,8 +197,8 @@ private with sharing class fflib_SObjectSelectorTest
 		{
 			return new List<Schema.SObjectField> {
 				Account.Name,
-				Account.AccountNumber,
 				Account.Id,
+				Account.AccountNumber,
 				Account.AnnualRevenue
 			};
 		}


### PR DESCRIPTION
Fixed test failures (hopefully the diff makes sense this time):

System.AssertException: Assertion Failed: Expected: Permission to access an Account dennied., Actual: Permission to access an Account denied.
Class.fflib_SObjectSelectorTest.testAssertIsAccessible: line 132, column 1

System.AssertException: Assertion Failed: Expected: Name,AccountNumber,Id,AnnualRevenue, Actual: AccountNumber,AnnualRevenue,Id,Name
Class.fflib_SObjectSelectorTest.testDefaultConfig: line 177, column 1

System.AssertException: Assertion Failed: Expected: myprefix.Name,myprefix.Id,myprefix.AccountNumber,myprefix.AnnualRevenue, Actual: myprefix.AccountNumber,myprefix.AnnualRevenue,myprefix.Id,myprefix.Name
Class.fflib_SObjectSelectorTest.testGetFieldListString: line 43, column 1
