### PR TITLE
Ability for SObjectUnitOfWork to resolve self-relationships

### DIFF
--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -252,7 +252,7 @@ public virtual class fflib_SObjectUnitOfWork
                 		// Resolve as many relationships as possible
 				for(Relationship relationship : objRelationships)
 				{
-					if(relationship.RelatedTo.Id != null)
+					if(relationship.RelatedTo.Id != null && !fakeIds.contains(relationship.RelatedTo.Id))
 					{
 						relationship.Record.put(relationship.RelatedToField, relationship.RelatedTo.Id);
 						relationship.Resolved = true;
@@ -335,11 +335,16 @@ public virtual class fflib_SObjectUnitOfWork
 	}
 	
 	static Integer s_num = 1;
+	// Keep a list of the fakeIds used, this is by no means foolproof as they could clash with a real
+	// Id, there has to be a better way
+	static Set<Id> fakeIds = new Set<Id>();
     
 	public static String getFakeId(Schema.SObjectType sot)
 	{
 		String result = String.valueOf(s_num++);
-		return sot.getDescribe().getKeyPrefix() + '0'.repeat(12-result.length()) + result;
+		String id = sot.getDescribe().getKeyPrefix() + '0'.repeat(12-result.length()) + result;
+		fakeIds.add(id);
+		return id;
 	}
 	
 	private class SObjectReferenceWrapper


### PR DESCRIPTION
Added the ability to handle self-relationships, e.g. 

```
fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(new Schema.SObjectType[] { Account.SObjectType });             
Account parent = new Account(Name = 'Parent');
uow.registerNew(parent);
uow.registerNew(new Account(Name = 'Child'), Account.ParentId, parent);
uow.registerNew(new Account(Name = 'Child'), Account.ParentId, parent);
uow.commitWork(); // inserts parent, then inserts children
```

This also allows you to process objects in multiple passes, for example:

```
fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(new Schema.SObjectType[] { Account.SObjectType, Custom__c.SObjectType, Account.SObjectType });             
Account parent = new Account(Name = 'Parent');
uow.registerNew(parent);

Custom__c custom = new Custom__c();
uow.registerNew(custom, Custom__c.ParentAccountId__c, parent);

Account child = new Account(Name = 'Child');
uow.registerNew(child, Account.ParentId, parent);
uow.registerRelationship(child, Account.CustomId__c, custom);
uow.commitWork(); // inserts parent, then custom, then finally child
```

This is massively hack-y at the moment, but it works... just about. I'm submitting this pull request early to expose the code to more eyes and to get input on to how I should develop this further. **This is NOT production ready**, it's pre-pre-alpha at best.

Known issues:
- Relies on fiddling with the Id field pre-insert, I can't find a better way of doing this whilst still allowing the public interface to work with SObjects
- Relies on a custom hashmap implementation to remain performant (although this is due to what I suspect is a platform bug, this reliance can be removed when this is fixed, see: http://salesforce.stackexchange.com/q/46525/5460)
- No error handling, e.g. no reporting of objects whose relationships cannot be resolved, they are just never inserted
- Currently no additional tests
