### PR TITLE
Update fflib_SObjectUnitOfWork.cls

### DIFF
--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls
@@ -304,7 +304,7 @@ public virtual class fflib_SObjectUnitOfWork
 
 		public void doWork()
 		{
-			Messaging.sendEmail(emails);
+			if(emails.size() > 0) Messaging.sendEmail(emails);
 		}
 	}	
 }


### PR DESCRIPTION
Messaging.sendEmail() was firing and eating up Email Invocations even with an empty list.
