### PR TITLE
Upgrade API version for UnitOfWork to 46.0 to allow new object types

### DIFF
--- a/fflib/src/classes/fflib_ISObjectUnitOfWork.cls-meta.xml
+++ b/fflib/src/classes/fflib_ISObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib/src/classes/fflib_SObjectUnitOfWork.cls-meta.xml
+++ b/fflib/src/classes/fflib_SObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls-meta.xml
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>37.0</apiVersion>
+    <apiVersion>46.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Object like ServiceResource and ServiceResourceSkill cannot be handled via UnitOfWork with API version 37.0, it results in the following error message: "Insufficient Privileges: You do not have the level of access necessary to perform the operation you requested."

Upgrading to API 46.0 resolves the issue