### PR TITLE
Immunity from Platform Encryption restriction on Order By

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cropredyHelix

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -1,0 +1,17 @@
+name: "Codeowners Validator"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    # Runs at 15:00 UTC every Monday
+    - cron: '0 15 * * 1'
+
+jobs:
+  call-workflow:
+    uses: myhelix/security-workflows/.github/workflows/codeowners-validator.yml@v1.0.0
+    secrets:
+      owners-validator-github-secret: ${{ secrets.OWNERS_VALIDATOR_PUBLIC_GITHUB_SECRET }}

--- a/fflib/src/classes/fflib_SObjectSelectorTest.cls
+++ b/fflib/src/classes/fflib_SObjectSelectorTest.cls
@@ -151,7 +151,7 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -208,7 +208,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		//Then
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		soqlMatcher.matches();
 
@@ -235,7 +235,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		// Assert that the
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
@@ -277,7 +277,7 @@ private with sharing class fflib_SObjectSelectorTest
 		
 		public override String getOrderBy()
 		{
-			return 'Name DESC, AnnualRevenue ASC NULLS LAST';
+			return 'AccountNumber DESC, AnnualRevenue ASC NULLS LAST';
 		}
 	}
 	

--- a/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/fflib/src/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -79,7 +79,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
                 Opportunity opp = new Opportunity();
                 opp.Name = 'UoW Test Name ' + o;
                 opp.StageName = 'Open';
-                opp.CloseDate = System.today();
+                opp.CloseDate = System.today().addDays(o);
                 uow.registerNew(new List<SObject>{opp});
                 for(Integer i=0; i<o+1; i++)
                 {
@@ -104,14 +104,13 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         }
 
         // Assert Results
-        assertResults('UoW');
+        assertResults(System.today());
         // TODO: Need to re-instate this check with a better approach, as it is not possible when
         //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
         // System.assertEquals(5 /* Oddly a setSavePoint consumes a DML */, Limits.getDmlStatements());
 
         // Records to update
-        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like 'UoW Test Name %' order by Name];
-
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where CloseDate >= TODAY order by CloseDate];
         // Update some records with UnitOfWork
         {
             fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
@@ -146,8 +145,8 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         // TODO: Need to re-instate this check with a better approach, as it is not possible when
         //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
         // System.assertEquals(11, Limits.getDmlStatements());
-        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity, TotalPrice from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
-        System.assertEquals(10, opps.size());
+        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity, TotalPrice from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where CloseDate >= TODAY  order by CloseDate];
+		System.assertEquals(10, opps.size());
         System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
         System.assertEquals(2, opps[0].OpportunityLineItems.size());
         // Verify that both fields were updated properly
@@ -173,19 +172,18 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         // TODO: Need to re-instate this check with a better approach, as it is not possible when
         //       product triggers contribute to DML (e.g. in sample app Opportunity trigger)
         // System.assertEquals(15, Limits.getDmlStatements());
-        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where Name like 'UoW Test Name %' order by Name];
-        List<Product2> prods = [Select Id from Product2 where Name = 'UoW Test Name 0 Changed : New Product'];
+        opps = [select Id, Name, (Select Id, PricebookEntry.Product2.Name, Quantity from OpportunityLineItems Order By PricebookEntry.Product2.Name) from Opportunity where CloseDate >= TODAY  order by CloseDate];
+		List<Product2> prods = [Select Id from Product2 where Name = 'UoW Test Name 0 Changed : New Product'];
         System.assertEquals(10, opps.size());
         System.assertEquals('UoW Test Name 0 Changed', opps[0].Name);
         System.assertEquals(1, opps[0].OpportunityLineItems.size()); // Should have deleted OpportunityLineItem added above
         System.assertEquals(0, prods.size()); // Should have deleted Product added above
     }
 
-    private static void assertResults(String prefix)
+    private static void assertResults(Date filter)
     {
         // Standard Assertions on tests data inserted by tests
-        String filter = prefix + ' Test Name %';
-        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name like :filter order by Name];
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where CloseDate >= :filter order by CloseDate];
         System.assertEquals(10, opps.size());
         System.assertEquals(1, opps[0].OpportunityLineItems.size());
         System.assertEquals(2, opps[1].OpportunityLineItems.size());
@@ -240,7 +238,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         uow.commitWork();
 
         // Assert Results
-        assertResults('UoW');
+        assertResults(System.today());
 
         assertEvents(new List<String> {
                 'onCommitWorkStarting'


### PR DESCRIPTION
[Issue](https://github.com/financialforcedev/fflib-apex-common/issues/237)

- Platform Encryption does not allow Order By or LIKE on encrypted fields.
- Account.Name and Opportunity.Name are used in testmethods with LIKE and/or Order By; both are potentially encryptable

SUMMARY OF CHANGES

- **fflib_SObjectSelectorTest:** Replace Order By Account.Name with Account.AccountNumber to avoid Platform Encryption restrictions
- **fflib_SObjectUnitOfWorkTest:** Replace Order By Opportunity.Name with Opportunity.CloseDate to avoid Platform Encryption restrictions (opportunities created with ascending close dates)

Note that at this time, neither

- Account.AccountNumber 
- Opportunity.CloseDate

can be encrypted so above change is "safe for now"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/236)
<!-- Reviewable:end -->
