### PR TITLE
ChildRelationship -> Schema.ChildRelationship

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -403,7 +403,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
 	**/
 	public fflib_QueryFactory subselectQuery(String relationshipName, Boolean assertIsAccessible){
-		ChildRelationship relationship = getChildRelationship(relationshipName);
+		Schema.ChildRelationship relationship = getChildRelationship(relationshipName);
 		if (relationship != null) {
 			return setSubselectQuery(relationship, assertIsAccessible);
 		}
@@ -416,7 +416,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
 	 * @param relationship The ChildRelationship to be added as a subquery
 	**/
-	public fflib_QueryFactory subselectQuery(ChildRelationship relationship){ 
+	public fflib_QueryFactory subselectQuery(Schema.ChildRelationship relationship){ 
 		return subselectQuery(relationship, false);
 	}
 
@@ -427,7 +427,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param relationship The ChildRelationship to be added as a subquery
 	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
 	**/
-	public fflib_QueryFactory subselectQuery(ChildRelationship relationship, Boolean assertIsAccessible){
+	public fflib_QueryFactory subselectQuery(Schema.ChildRelationship relationship, Boolean assertIsAccessible){
 		return setSubselectQuery(relationship, assertIsAccessible);
 	}
 
@@ -437,12 +437,12 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @exception InvalidSubqueryRelationshipException If this method is called on a subselectQuery or with an invalid relationship 
 	 * @param relationship The ChildRelationship to be added as a subquery
 	**/
-	private fflib_QueryFactory setSubselectQuery(ChildRelationship relationship, Boolean assertIsAccessible){
+	private fflib_QueryFactory setSubselectQuery(Schema.ChildRelationship relationship, Boolean assertIsAccessible){
 		if (this.relationship != null){
 			throw new InvalidSubqueryRelationshipException('Invalid call to subselectQuery.  You may not add a subselect query to a subselect query.');
 		} 
 		if (this.subselectQueryMap == null){
-			this.subselectQueryMap = new Map<ChildRelationship, fflib_QueryFactory>();
+			this.subselectQueryMap = new Map<Schema.ChildRelationship, fflib_QueryFactory>();
 		}
 		if (this.subselectQueryMap.containsKey(relationship)){
 			return subselectQueryMap.get(relationship);

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -495,7 +495,7 @@ private class fflib_QueryFactoryTest {
 		qf.setCondition( 'name like \'%test%\'' );
 		qf.addOrdering( new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) ).addOrdering('CreatedBy.Name',fflib_QueryFactory.SortOrder.DESCENDING);
 		Schema.DescribeSObjectResult descResult = Contact.SObjectType.getDescribe();
-       	ChildRelationship relationship;
+       	Schema.ChildRelationship relationship;
         for (Schema.ChildRelationship childRow : descResult.getChildRelationships()) {
             if (childRow.getRelationshipName() == 'Tasks') {
                 relationship = childRow;


### PR DESCRIPTION
Refactored references to ChildRelationship with Schema.ChildRelationship to avoid name collisions with custom class named "ChildRelationship" that may be present on an org.