### PR TITLE
233 list out of bounds query factory

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -84,13 +84,19 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	private Schema.ChildRelationship relationship;
 	private Map<Schema.ChildRelationship, fflib_QueryFactory> subselectQueryMap;
 
-	private String getFieldPath(String fieldName){
+	private String getFieldPath(String fieldName)
+	{
+		if (!enforceFLS)
+		{
+			// There is no need to validate FLS for individual fields in the relationship
+			return fieldName;
+		}
+
 		if(!fieldName.contains('.')){ //single field
 			Schema.SObjectField token = fflib_SObjectDescribe.getDescribe(table).getField(fieldName.toLowerCase());
 			if(token == null)
 				throw new InvalidFieldException(fieldName,this.table);
-			if (enforceFLS) 
-				fflib_SecurityUtils.checkFieldIsReadable(this.table, token);	
+			fflib_SecurityUtils.checkFieldIsReadable(this.table, token);
 			return token.getDescribe().getName();
 		}
 
@@ -103,7 +109,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 			Schema.SObjectField token = fflib_SObjectDescribe.getDescribe(lastSObjectType).getField(field.toLowerCase());
 			DescribeFieldResult tokenDescribe = token != null ? token.getDescribe() : null;
 			
-			if (token != null && enforceFLS) {
+			if (token != null) {
 				fflib_SecurityUtils.checkFieldIsReadable(lastSObjectType, token);
 			}
 


### PR DESCRIPTION
#233 Fix for list out of bounds error in QueryFactory when executed without sharing for a community user on an object that the user doesn't have access to.

When a query with a relationship fields in the select is generated for a community user in a without sharing context on an object that is not accessible (CRUD), a list out of bounds error is returned.

The method Schema.getGlobalDescribe().get('NonAccessibleObjectName__c').getDescribe().fields.getMap().get('MyRelationShipFieldToAnotherNonAccessibleObject__c').getDescribe().getReferenceTo() will return null when executed as community user.

While if we get the describe of that SObject for that relationship field via Schema.getGlobalDescribe().get('NonAccessibleRelationshipObjectName__c').getDescribe(), it will just return the expected describe.

So we have access to both SObjects, as expected because we run without sharing, but we do not have access to get the getReferenceTo on the relationship field between both SObjects.

As the purpose of this getFieldPath method is to validate the field level security for individual fields in the referred relationship, we can bypass this whole method when enforceFLS is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/251)
<!-- Reviewable:end -->
