### PR TITLE
Enabling SOQL functions (#163)

### DIFF
--- a/fflib/src/classes/fflib_QueryFactory.cls
+++ b/fflib/src/classes/fflib_QueryFactory.cls
@@ -84,17 +84,51 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	private Schema.ChildRelationship relationship;
 	private Map<Schema.ChildRelationship, fflib_QueryFactory> subselectQueryMap;
 
-	private String getFieldPath(String fieldName){
-		if(!fieldName.contains('.')){ //single field
-			Schema.SObjectField token = fflib_SObjectDescribe.getDescribe(table).getField(fieldName.toLowerCase());
-			if(token == null)
-				throw new InvalidFieldException(fieldName,this.table);
-			if (enforceFLS) 
-				fflib_SecurityUtils.checkFieldIsReadable(this.table, token);	
-			return token.getDescribe().getName();
+	/**
+	 * Pattern variable to prevent the Pattern to be compiled for each field
+	 */
+	private Pattern soqlFunctionPattern { get{
+		if( soqlFunctionPattern == null ){
+			soqlFunctionPattern = Pattern.compile( '^([a-zA-Z_]*\\(\\s*)([a-zA-Z0-9_\\.]+)?(\\s*\\)[a-zA-Z ]*)$' );
+		}
+		return soqlFunctionPattern;
+	} set; }
+
+	private String getFieldPath( String fieldName ){
+		// Check whether field contains a SOQL function statement - if so, split from field
+		String beforeField = '';
+		String afterField = '';
+		if( fieldName.contains( '(' ) ){
+			// Splitting string into three groups: [ 'METHOD( ', 'Field__c', ') as c' ]
+			Matcher match = this.soqlFunctionPattern.matcher( fieldName );
+
+			if( match.matches() ){
+				beforeField = match.group( 1 );
+				fieldName = match.group( 2 );
+				afterField = match.group( 3 );
+
+				// When no fieldName is specified (e.g. COUNT() ), return directly, since nothing to check
+				if( String.isBlank( fieldName ) ){
+					return beforeField + afterField;
+				}
+			} else{
+				throw new InvalidFieldException( 'The field '+ fieldName + 'does specify a ( function opening, but doesn\'t match the pattern' );
+			}
 		}
 
-		//traversing FK relationship(s)
+		if( !fieldName.contains( '.' ) ){ //single field
+			Schema.SObjectField token = fflib_SObjectDescribe.getDescribe(table).getField(fieldName.toLowerCase());
+			if( token == null ){
+				throw new InvalidFieldException( fieldName, this.table );
+			}
+			if( enforceFLS ){
+				fflib_SecurityUtils.checkFieldIsReadable( this.table, token );
+			}
+			// Once verified field exists and user has access, include function parts back in
+			return beforeField + token.getDescribe().getName() + afterField;
+		}
+
+		// Traversing FK relationship(s)
 		List<String> fieldPath = new List<String>();
 		Schema.sObjectType lastSObjectType = table;
 		Iterator<String> i = fieldName.split('\\.').iterator();
@@ -113,14 +147,15 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 			}else if(token != null && !i.hasNext()){
 				fieldPath.add(tokenDescribe.getName());
 			}else{
-				if(token == null)
-					throw new InvalidFieldException(field,lastSObjectType);
-				else
-					throw new NonReferenceFieldException(lastSObjectType+'.'+field+' is not a lookup or master-detail field but is used in a cross-object query field.');
+				if(token == null){
+					throw new InvalidFieldException( field, lastSObjectType );
+				} else{
+					throw new NonReferenceFieldException( lastSObjectType + '.' + field + ' is not a lookup or master-detail field but is used in a cross-object query field.' );
+				}
 			}
 		}
 
-		return String.join(fieldPath,'.');
+		return beforeField + String.join( fieldPath, '.' ) + afterField;
 	}
 
 	@TestVisible

--- a/fflib/src/classes/fflib_QueryFactoryTest.cls
+++ b/fflib/src/classes/fflib_QueryFactoryTest.cls
@@ -80,6 +80,35 @@ private class fflib_QueryFactoryTest {
 	}
 
 	@isTest
+	static void selectFunction_COUNT() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField( 'COUNT()' );
+		qf.selectField( 'COUNT( eMail ) as countEmail' );
+		qf.selectField( 'COUNT_DISTINCT( Name )' );
+		String query = qf.toSOQL();
+		System.assertEquals( 'SELECT COUNT( Email ) as countEmail, COUNT(), COUNT_DISTINCT( Name ) FROM Contact', query, 'Expected COUNT fields to be in query '+ query );
+	}
+
+	@isTest
+	static void selectFunction_ToLabel() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		qf.selectField( 'toLabel(Name)' );
+		String query = qf.toSOQL();
+		System.assertEquals( 'SELECT toLabel(Name) FROM Contact', query, 'Expected COUNT fields to be in query '+ query );
+	}
+
+	@isTest
+	static void selectFunction_Exception() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
+		try{
+			qf.selectField( 'AVG( MIN( CreatedDate ) )' );
+			System.assert( false, 'Expected exception to be thrown' );
+		} catch( Exception ex ){
+			System.assert( ex.getMessage().contains( 'does specify a ( function opening' ), 'Expected exception to be thrown' );
+		}
+	}
+
+	@isTest
 	static void equalityCheck(){
 		fflib_QueryFactory qf1 = new fflib_QueryFactory(Contact.SObjectType);
 		fflib_QueryFactory qf2 = new fflib_QueryFactory(Contact.SObjectType);


### PR DESCRIPTION
Enrichment to the fflib Query Factory to allow soql methods (like COUNT(), toLabel, and such) to be specified. Note, they can be added via `selectFields( String(s) )` methods, as is illustrated in the provided test methods.