### PR TITLE
#199 - mark fflib_SObjectSelector methods as virtual

### DIFF
--- a/fflib/src/classes/fflib_SObjectSelector.cls
+++ b/fflib/src/classes/fflib_SObjectSelector.cls
@@ -296,7 +296,7 @@ public abstract with sharing class fflib_SObjectSelector
      *   - Ordered by the fields returned via getOrderBy
      * @returns A list of SObject's
      **/
-    public List<SObject> selectSObjectsById(Set<Id> idSet)
+    public virtual List<SObject> selectSObjectsById(Set<Id> idSet)
     {
         return Database.query(buildQuerySObjectById());
     }
@@ -309,7 +309,7 @@ public abstract with sharing class fflib_SObjectSelector
      *   - Ordered by the fields returned via getOrderBy
      * @returns A QueryLocator (typically for use in a Batch Apex job)
      **/
-    public Database.QueryLocator queryLocatorById(Set<Id> idSet)
+    public virtual Database.QueryLocator queryLocatorById(Set<Id> idSet)
     {
         return Database.getQueryLocator(buildQuerySObjectById());
     }


### PR DESCRIPTION
The purpose of this pull request is to address the core problem outlined in #199 -- that is, that it's impossible to change the sharing model behavior of the `fflib_SObjectSelector` and `fflib_SObjectDomain` class via the sharing model declared on the derived class. 

There is some discussion over on https://github.com/apex-enterprise-patterns/fflib-apex-common/pull/251#issuecomment-570233351 -- the notable point in that thread is that the only behavior affected by the sharing model is SOQL (inline SOQL or Database.query()) or DML (insert/update/delete or Database.insert/update/delete) defined within those class files. As such, if you declare your Domain class or Selector class `without sharing`, that's exactly what you'll get (all of your SOQL will run `without sharing`). The `with sharing` clause on the base classes is irrelevant EXCEPT for one case: `fflib_SObjectSelector.selectSObjectsById()` and `fflib_SObjectSelector.queryLocatorById()` do directly call `Database.query()`

It is my belief through experimentation that `fflib_SObjectDomain`'s sharing declaration is irrelevant for all practical use cases. No SOQL or DML is present in `fflib_SObjectDomain`

The original PR proposed to fix #199 is #200 and that got to be super deep (introducing a whole new `fflib_SObjectSelector2` to address backwards compatibility). It left us with the decision to either muddy up the API surface area or break backwards compat by removing the 'with sharing' keyword from fflib_SObjectSelector

This PR is a very narrow, non-breaking, workaround. It allows a developer to override the two methods affected by sharing (again `fflib_SObjectSelector.selectSObjectsById()` and `fflib_SObjectSelector.queryLocatorById()`) in their Selector subclass and direclty call `Database.query(buildQuerySObjectById())` within their `without sharing` class

Example:

```
public without sharing class MyElevatedAccountSelector extends fflib_SObjectSelector{
  public override selectSObjectsById(Set<Id> idSet){
    return Database.query(buildQuerySObjectById());
  }
}
```

cc @wimvelzeboer @ImJohnMDaniel @yurybond 



