### PR TITLE
Provide ability to skip dml operations using default SimpleDML class

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -90,37 +90,60 @@ public virtual class fflib_SObjectUnitOfWork
         void dmlUpdate(List<SObject> objList);
         void dmlDelete(List<SObject> objList);
         void eventPublish(List<SObject> objList);
-	    void emptyRecycleBin(List<SObject> objList);
+        void emptyRecycleBin(List<SObject> objList);
     }
 
     public class SimpleDML implements IDML
     {
         public void dmlInsert(List<SObject> objList)
         {
-            insert objList;
+            if (executingDMLOperations)
+            {
+                insert objList;
+            }
         }
+
         public void dmlUpdate(List<SObject> objList)
         {
-            update objList;
+            if (executingDMLOperations)
+            {
+                update objList;
+            }
         }
+
         public void dmlDelete(List<SObject> objList)
         {
-            delete objList;
+            if (executingDMLOperations)
+            {
+                delete objList;
+            }
         }
+
         public void eventPublish(List<SObject> objList)
         {
-            EventBus.publish(objList);
+            if (executingDMLOperations) EventBus.publish(objList);
         }
-		public void emptyRecycleBin(List<SObject> objList)
-		{
-			if (objList.isEmpty())
-			{
-				return;
-			}
 
-			Database.emptyRecycleBin(objList);
-		}
+        public void emptyRecycleBin(List<SObject> objList)
+        {
+            if (objList.isEmpty())
+            {
+                return;
+            }
+
+            Database.emptyRecycleBin(objList);
+        }
+
+        /******* Unit Test facilitation *******/
+        private Boolean executingDMLOperations = true;
+
+        @TestVisible
+        private void setExecuteDMLOperations(Boolean value)
+        {
+            executingDMLOperations = value;
+        }
     }
+
     /**
      * Constructs a new UnitOfWork to support work against the given object list
      *
@@ -141,7 +164,7 @@ public virtual class fflib_SObjectUnitOfWork
             handleRegisterType(sObjectType);
         }
 
-		m_relationships.put(Messaging.SingleEmailMessage.class.getName(), new Relationships());
+        m_relationships.put(Messaging.SingleEmailMessage.class.getName(), new Relationships());
 
         m_dml = dml;
     }
@@ -182,7 +205,7 @@ public virtual class fflib_SObjectUnitOfWork
         m_newListByType.put(sObjectName, new List<SObject>());
         m_dirtyMapByType.put(sObjectName, new Map<Id, SObject>());
         m_deletedMapByType.put(sObjectName, new Map<Id, SObject>());
-	    m_emptyRecycleBinMapByType.put(sObjectName, new Map<Id, SObject>());
+        m_emptyRecycleBinMapByType.put(sObjectName, new Map<Id, SObject>());
         m_relationships.put(sObjectName, new Relationships());
 
         m_publishBeforeListByType.put(sObjectName, new List<SObject>());
@@ -209,31 +232,31 @@ public virtual class fflib_SObjectUnitOfWork
         m_emailWork.registerEmail(email);
     }
 
-	/**
-	 * Register an deleted record to be removed from the recycle bin during the commitWork method
-	 *
-	 * @param record An deleted record
-	 **/
-	public void registerEmptyRecycleBin(SObject record)
-	{
-		String sObjectType = record.getSObjectType().getDescribe().getName();
-		assertForSupportedSObjectType(m_emptyRecycleBinMapByType, sObjectType);
+    /**
+     * Register an deleted record to be removed from the recycle bin during the commitWork method
+     *
+     * @param record An deleted record
+     **/
+    public void registerEmptyRecycleBin(SObject record)
+    {
+        String sObjectType = record.getSObjectType().getDescribe().getName();
+        assertForSupportedSObjectType(m_emptyRecycleBinMapByType, sObjectType);
 
-		m_emptyRecycleBinMapByType.get(sObjectType).put(record.Id, record);
-	}
+        m_emptyRecycleBinMapByType.get(sObjectType).put(record.Id, record);
+    }
 
-	/**
-	 * Register deleted records to be removed from the recycle bin during the commitWork method
-	 *
-	 * @param records Deleted records
-	 **/
-	public void registerEmptyRecycleBin(List<SObject> records)
-	{
-		for (SObject record : records)
-		{
-			registerEmptyRecycleBin(record);
-		}
-	}
+    /**
+     * Register deleted records to be removed from the recycle bin during the commitWork method
+     *
+     * @param records Deleted records
+     **/
+    public void registerEmptyRecycleBin(List<SObject> records)
+    {
+        for (SObject record : records)
+        {
+            registerEmptyRecycleBin(record);
+        }
+    }
 
     /**
      * Register a newly created SObject instance to be inserted when commitWork is called
@@ -272,8 +295,8 @@ public virtual class fflib_SObjectUnitOfWork
             throw new UnitOfWorkException('Only new records can be registered as new');
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForNonEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_newListByType, sObjectType);
+        assertForNonEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_newListByType, sObjectType);
 
         m_newListByType.get(sObjectType).add(record);
         if (relatedToParentRecord!=null && relatedToParentField!=null)
@@ -292,8 +315,8 @@ public virtual class fflib_SObjectUnitOfWork
     {
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForNonEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_newListByType, sObjectType);
+        assertForNonEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_newListByType, sObjectType);
 
         m_relationships.get(sObjectType).add(record, relatedToField, relatedTo);
     }
@@ -349,8 +372,8 @@ public virtual class fflib_SObjectUnitOfWork
             throw new UnitOfWorkException('New records cannot be registered as dirty');
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForNonEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_dirtyMapByType, sObjectType);
+        assertForNonEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_dirtyMapByType, sObjectType);
 
         // If record isn't registered as dirty, or no dirty fields to drive a merge
         if (!m_dirtyMapByType.get(sObjectType).containsKey(record.Id) || dirtyFields.isEmpty())
@@ -385,8 +408,8 @@ public virtual class fflib_SObjectUnitOfWork
             throw new UnitOfWorkException('New records cannot be registered as dirty');
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForNonEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_dirtyMapByType, sObjectType);
+        assertForNonEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_dirtyMapByType, sObjectType);
 
         m_dirtyMapByType.get(sObjectType).put(record.Id, record);
         if (relatedToParentRecord!=null && relatedToParentField!=null)
@@ -447,8 +470,8 @@ public virtual class fflib_SObjectUnitOfWork
             throw new UnitOfWorkException('New records cannot be registered for deletion');
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForNonEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_deletedMapByType, sObjectType);
+        assertForNonEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_deletedMapByType, sObjectType);
 
         m_deletedMapByType.get(sObjectType).put(record.Id, record);
     }
@@ -466,25 +489,25 @@ public virtual class fflib_SObjectUnitOfWork
         }
     }
 
-	/**
+    /**
      * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
      *
      * @param records A list of existing records
      **/
     public void registerPermanentlyDeleted(List<SObject> records)
     {
-	    this.registerEmptyRecycleBin(records);
-	    this.registerDeleted(records);
+        this.registerEmptyRecycleBin(records);
+        this.registerDeleted(records);
     }
 
-	/**
+    /**
      * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
      *
      * @param records A list of existing records
      **/
     public void registerPermanentlyDeleted(SObject record)
     {
-	    this.registerEmptyRecycleBin(record);
+        this.registerEmptyRecycleBin(record);
         this.registerDeleted(record);
     }
 
@@ -497,8 +520,8 @@ public virtual class fflib_SObjectUnitOfWork
     {
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_publishBeforeListByType, sObjectType);
+        assertForEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_publishBeforeListByType, sObjectType);
 
         m_publishBeforeListByType.get(sObjectType).add(record);
     }
@@ -525,8 +548,8 @@ public virtual class fflib_SObjectUnitOfWork
     {
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_publishAfterSuccessListByType, sObjectType);
+        assertForEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_publishAfterSuccessListByType, sObjectType);
 
         m_publishAfterSuccessListByType.get(sObjectType).add(record);
     }
@@ -543,6 +566,7 @@ public virtual class fflib_SObjectUnitOfWork
             this.registerPublishAfterSuccessTransaction(record);
         }
     }
+
     /**
      * Register a newly created SObject (Platform Event) instance to be published when commitWork is called
      *
@@ -552,8 +576,8 @@ public virtual class fflib_SObjectUnitOfWork
     {
         String sObjectType = record.getSObjectType().getDescribe().getName();
 
-		assertForEventSObjectType(sObjectType);
-		assertForSupportedSObjectType(m_publishAfterFailureListByType, sObjectType);
+        assertForEventSObjectType(sObjectType);
+        assertForSupportedSObjectType(m_publishAfterFailureListByType, sObjectType);
 
         m_publishAfterFailureListByType.get(sObjectType).add(record);
     }
@@ -574,186 +598,186 @@ public virtual class fflib_SObjectUnitOfWork
     /**
      * Takes all the work that has been registered with the UnitOfWork and commits it to the database
      **/
-	public void commitWork()
-	{
-		Savepoint sp = Database.setSavePoint();
-		Boolean wasSuccessful = false;
-		try
-		{
-			doCommitWork();
-			wasSuccessful = true;
-		}
-		catch (Exception e)
-		{
-			Database.rollback(sp);
-			throw e;
-		}
-		finally
-		{
-			doAfterCommitWorkSteps(wasSuccessful);
-		}
-	}
+    public void commitWork()
+    {
+        Savepoint sp = Database.setSavePoint();
+        Boolean wasSuccessful = false;
+        try
+        {
+            doCommitWork();
+            wasSuccessful = true;
+        }
+        catch (Exception e)
+        {
+            Database.rollback(sp);
+            throw e;
+        }
+        finally
+        {
+            doAfterCommitWorkSteps(wasSuccessful);
+        }
+    }
 
-	private void doCommitWork()
-	{
-		onCommitWorkStarting();
-		onPublishBeforeEventsStarting();
-		publishBeforeEventsStarting();
-		onPublishBeforeEventsFinished();
+    private void doCommitWork()
+    {
+        onCommitWorkStarting();
+        onPublishBeforeEventsStarting();
+        publishBeforeEventsStarting();
+        onPublishBeforeEventsFinished();
 
-		onDMLStarting();
-		insertDmlByType();
-		updateDmlByType();
-		deleteDmlByType();
-		emptyRecycleBinByType();
-		resolveEmailRelationships();
-		onDMLFinished();
+        onDMLStarting();
+        insertDmlByType();
+        updateDmlByType();
+        deleteDmlByType();
+        emptyRecycleBinByType();
+        resolveEmailRelationships();
+        onDMLFinished();
 
-		onDoWorkStarting();
-		doWork();
-		onDoWorkFinished();
-		onCommitWorkFinishing();
-	}
+        onDoWorkStarting();
+        doWork();
+        onDoWorkFinished();
+        onCommitWorkFinishing();
+    }
 
-	private void doAfterCommitWorkSteps(Boolean wasSuccessful)
-	{
-		if (wasSuccessful)
-		{
-			doAfterCommitWorkSuccessSteps();
-		}
-		else
-		{
-			doAfterCommitWorkFailureSteps();
-		}
-		onCommitWorkFinished(wasSuccessful);
-	}
+    private void doAfterCommitWorkSteps(Boolean wasSuccessful)
+    {
+        if (wasSuccessful)
+        {
+            doAfterCommitWorkSuccessSteps();
+        }
+        else
+        {
+            doAfterCommitWorkFailureSteps();
+        }
+        onCommitWorkFinished(wasSuccessful);
+    }
 
-	private void doAfterCommitWorkSuccessSteps()
-	{
-		onPublishAfterSuccessEventsStarting();
-		publishAfterSuccessEvents();
-		onPublishAfterSuccessEventsFinished();
-	}
+    private void doAfterCommitWorkSuccessSteps()
+    {
+        onPublishAfterSuccessEventsStarting();
+        publishAfterSuccessEvents();
+        onPublishAfterSuccessEventsFinished();
+    }
 
-	private void doAfterCommitWorkFailureSteps()
-	{
-		onPublishAfterFailureEventsStarting();
-		publishAfterFailureEvents();
-		onPublishAfterFailureEventsFinished();
-	}
+    private void doAfterCommitWorkFailureSteps()
+    {
+        onPublishAfterFailureEventsStarting();
+        publishAfterFailureEvents();
+        onPublishAfterFailureEventsFinished();
+    }
 
-	private void publishBeforeEventsStarting()
-	{
-		for (Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			m_dml.eventPublish(m_publishBeforeListByType.get(sObjectType.getDescribe().getName()));
-		}
-	}
+    private void publishBeforeEventsStarting()
+    {
+        for (Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            m_dml.eventPublish(m_publishBeforeListByType.get(sObjectType.getDescribe().getName()));
+        }
+    }
 
-	private void insertDmlByType()
-	{
-		for (Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			m_relationships.get(sObjectType.getDescribe().getName()).resolve();
-			m_dml.dmlInsert(m_newListByType.get(sObjectType.getDescribe().getName()));
-		}
-	}
+    private void insertDmlByType()
+    {
+        for (Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            m_relationships.get(sObjectType.getDescribe().getName()).resolve();
+            m_dml.dmlInsert(m_newListByType.get(sObjectType.getDescribe().getName()));
+        }
+    }
 
-	private void updateDmlByType()
-	{
-		for (Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			m_dml.dmlUpdate(m_dirtyMapByType.get(sObjectType.getDescribe().getName()).values());
-		}
-	}
+    private void updateDmlByType()
+    {
+        for (Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            m_dml.dmlUpdate(m_dirtyMapByType.get(sObjectType.getDescribe().getName()).values());
+        }
+    }
 
-	private void deleteDmlByType()
-	{
-		Integer objectIdx = m_sObjectTypes.size() - 1;
-		while (objectIdx >= 0)
-		{
-			m_dml.dmlDelete(m_deletedMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
-		}
-	}
+    private void deleteDmlByType()
+    {
+        Integer objectIdx = m_sObjectTypes.size() - 1;
+        while (objectIdx >= 0)
+        {
+            m_dml.dmlDelete(m_deletedMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
+        }
+    }
 
-	private void emptyRecycleBinByType()
-	{
-		Integer objectIdx = m_sObjectTypes.size() - 1;
-		while (objectIdx >= 0)
-		{
-			m_dml.emptyRecycleBin(m_emptyRecycleBinMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
-		}
-	}
+    private void emptyRecycleBinByType()
+    {
+        Integer objectIdx = m_sObjectTypes.size() - 1;
+        while (objectIdx >= 0)
+        {
+            m_dml.emptyRecycleBin(m_emptyRecycleBinMapByType.get(m_sObjectTypes[objectIdx--].getDescribe().getName()).values());
+        }
+    }
 
-	private void resolveEmailRelationships()
-	{
-		m_relationships.get(Messaging.SingleEmailMessage.class.getName()).resolve();
-	}
+    private void resolveEmailRelationships()
+    {
+        m_relationships.get(Messaging.SingleEmailMessage.class.getName()).resolve();
+    }
 
-	private void doWork()
-	{
-		m_workList.add(m_emailWork);
-		for (IDoWork work : m_workList)
-		{
-			work.doWork();
-		}
-	}
+    private void doWork()
+    {
+        m_workList.add(m_emailWork);
+        for (IDoWork work : m_workList)
+        {
+            work.doWork();
+        }
+    }
 
-	private void publishAfterSuccessEvents()
-	{
-		for (Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			m_dml.eventPublish(m_publishAfterSuccessListByType.get(sObjectType.getDescribe().getName()));
-		}
-	}
+    private void publishAfterSuccessEvents()
+    {
+        for (Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            m_dml.eventPublish(m_publishAfterSuccessListByType.get(sObjectType.getDescribe().getName()));
+        }
+    }
 
-	private void publishAfterFailureEvents()
-	{
-		for (Schema.SObjectType sObjectType : m_sObjectTypes)
-		{
-			m_dml.eventPublish(m_publishAfterFailureListByType.get(sObjectType.getDescribe().getName()));
-		}
-	}
+    private void publishAfterFailureEvents()
+    {
+        for (Schema.SObjectType sObjectType : m_sObjectTypes)
+        {
+            m_dml.eventPublish(m_publishAfterFailureListByType.get(sObjectType.getDescribe().getName()));
+        }
+    }
 
-	private void assertForNonEventSObjectType(String sObjectType)
-	{
-		if (sObjectType.length() > 3 && sObjectType.right(3)  == '__e')
-		{
-			throw new UnitOfWorkException(
-					String.format(
-							'SObject type {0} must use registerPublishBeforeTransaction or ' +
-									'registerPublishAfterTransaction methods to be used within this unit of work',
-							new List<String> { sObjectType }
-					)
-			);
-		}
-	}
+    private void assertForNonEventSObjectType(String sObjectType)
+    {
+        if (sObjectType.length() > 3 && sObjectType.right(3)  == '__e')
+        {
+            throw new UnitOfWorkException(
+                    String.format(
+                            'SObject type {0} must use registerPublishBeforeTransaction or ' +
+                                    'registerPublishAfterTransaction methods to be used within this unit of work',
+                            new List<String> { sObjectType }
+                    )
+            );
+        }
+    }
 
-	private void assertForEventSObjectType(String sObjectType)
-	{
-		if (sObjectType.length() > 3 && sObjectType.right(3) != '__e')
-		{
-			throw new UnitOfWorkException(
-					String.format(
-							'SObject type {0} is invalid for publishing within this unit of work',
-							new List<String> {sObjectType}
-					)
-			);
-		}
-	}
+    private void assertForEventSObjectType(String sObjectType)
+    {
+        if (sObjectType.length() > 3 && sObjectType.right(3) != '__e')
+        {
+            throw new UnitOfWorkException(
+                    String.format(
+                            'SObject type {0} is invalid for publishing within this unit of work',
+                            new List<String> {sObjectType}
+                    )
+            );
+        }
+    }
 
-	private void assertForSupportedSObjectType(Map<String, Object> theMap, String sObjectType)
-	{
-		if (!theMap.containsKey(sObjectType))
-		{
-			throw new UnitOfWorkException(
-					String.format(
-							'SObject type {0} is not supported by this unit of work',
-							new List<String> { sObjectType }
-					)
-			);
-		}
-	}
+    private void assertForSupportedSObjectType(Map<String, Object> theMap, String sObjectType)
+    {
+        if (!theMap.containsKey(sObjectType))
+        {
+            throw new UnitOfWorkException(
+                    String.format(
+                            'SObject type {0} is not supported by this unit of work',
+                            new List<String> { sObjectType }
+                    )
+            );
+        }
+    }
 
     private class Relationships
     {

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -69,6 +69,72 @@ private with sharing class fflib_SObjectUnitOfWorkTest
     }
 
     @isTest
+    private static void TestSkippingDMLOperations_Default_ExecuteDMLIsTrue()
+    {
+        string testRecordName = 'UoW Test Name 1';
+
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
+
+        Opportunity opp = new Opportunity();
+        opp.Name = testRecordName;
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew( opp );
+
+        uow.commitWork();
+
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name = :testRecordName order by Name];
+
+        System.assertEquals(1, opps.size());
+    }
+
+    @isTest
+    private static void TestSkippingDMLOperations_ExplicitlySetExecuteDMLToTrue()
+    {
+        string testRecordName = 'UoW Test Name 1';
+
+        fflib_SObjectUnitOfWork.SimpleDML dml = new fflib_SObjectUnitOfWork.SimpleDML();
+        dml.setExecuteDMLOperations(true);
+
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS, dml);
+
+        Opportunity opp = new Opportunity();
+        opp.Name = testRecordName;
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew( opp );
+
+        uow.commitWork();
+
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name = :testRecordName order by Name];
+
+        System.assertEquals(1, opps.size());
+    }
+
+    @isTest
+    private static void TestSkippingDMLOperations_ExplicitlySetExecuteDMLToFalse()
+    {
+        string testRecordName = 'UoW Test Name 1';
+
+        fflib_SObjectUnitOfWork.SimpleDML dml = new fflib_SObjectUnitOfWork.SimpleDML();
+        dml.setExecuteDMLOperations(false);
+
+        fflib_SObjectUnitOfWork uow = new fflib_SObjectUnitOfWork(MY_SOBJECTS, dml);
+
+        Opportunity opp = new Opportunity();
+        opp.Name = testRecordName;
+        opp.StageName = 'Open';
+        opp.CloseDate = System.today();
+        uow.registerNew( opp );
+
+        uow.commitWork();
+
+        List<Opportunity> opps = [select Id, Name, (Select Id from OpportunityLineItems) from Opportunity where Name = :testRecordName order by Name];
+
+        System.assertEquals(0, opps.size());
+    }
+
+    @isTest
     private static void testUnitOfWorkNewDirtyDelete()
     {
         // Insert Opportunities with UnitOfWork


### PR DESCRIPTION
Add `@TestVisible` feature to default `SimpleDML` class that easily enables skipping of DML operations during mock-based unit testing.  Workaround was writing inert, mock `IDML` class without any DML operations.

See `fflib_SObjectUnitOfWorkTest` for example usage.  Snippet here.
```
    // Within the scope of a unit test.
    fflib_SObjectUnitOfWork.SimpleDML dml = new fflib_SObjectUnitOfWork.SimpleDML();
    dml.setExecuteDMLOperations(false);

    // Where MyApplication is an extension of fflib_Application per related Samples
    MyApplication.UnitOfWork.setMock(new fflib_SObjectUnitOfWork(MY_SOBJECTS, dml));
```
Significant code changes in `fflib_SObjectUnitOfWork.SimpleDML` and new lines 71 through 136 in `fflib_SObjectUnitOfWorkTest`.

`fflib_SObjectUnitOfWork` includes whitespace, indentation consistency change.