### PR TITLE
Add IntelliJ config files to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,13 @@ Referenced Packages/
 .vscode/
 .history/
 
+# IntelliJ IDE Related
+.idea/
+*.iml
+*.iws
+IlluminatedCloud/
+.project.license
+
 # SFDX Related
 .sfdx/
 sfdx-source/common-base/main/default/


### PR DESCRIPTION
IntelliJ & Illuminated Cloud configuration files were not yet ignored in GIT. This will add that and prevent those files from being committed.