### PR TITLE
Fixes #260 - replaces Travis with GH Action workflow

### DIFF
--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -14,7 +14,8 @@ jobs:
           repository: apex-enterprise-patterns/fflib-apex-mocks
           path: fflib-apex-mocks
       - name: Hack the sfdx-project.json to prepend the second package directory for fflib-apex-mocks
-        run: cat sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
+        run: cat sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project2.json
+      - run: mv sfdx-project2.json sfdx-project.json
       - run: cat sfdx-project.json
       - name: Install SFDX CLI and authorize DevHub
         uses: apex-enterprise-patterns/setup-sfdx@v1 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
       - run: cat sfdx-project.json
       - name: Install SFDX CLI and authorize DevHub
-        uses: sfdx-actions/setup-sfdx@v1 #Might want to consider forking this guy's GH Action repo for safety
+        uses: apex-enterprise-patterns/setup-sfdx@v1 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
       - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -14,7 +14,7 @@ jobs:
           repository: apex-enterprise-patterns/fflib-apex-mocks
           path: fflib-apex-mocks
       - name: Hack the sfdx-project.json to prepend the second package directory for fflib-apex-mocks
-        run: echo sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
+        run: cat sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
       - run: cat sfdx-project.json
       - name: Install SFDX CLI and authorize DevHub
         uses: apex-enterprise-patterns/setup-sfdx@v1 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2 #Check out this repo
-      - uses: actions/checkout@v2 #Checkout fflib-apex-mocks
+      - uses: actions/checkout@v2 #Checkout fflib-apex-mocks as a sibling of this repo
         with:
           repository: apex-enterprise-patterns/fflib-apex-mocks
           path: fflib-apex-mocks

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -2,9 +2,7 @@ name: Create a Scratch Org, Push Source and Run Apex Tests
 
 on:
   push:
-    branches:
-    - master
-  pull_request:
+  pull_request_target:
   
 jobs:
   build:
@@ -12,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2 #Check out this repo
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Install SFDX CLI and authorize DevHub
         uses: apex-enterprise-patterns/setup-sfdx@v1 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety
         with:

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -1,7 +1,11 @@
 name: Create a Scratch Org, Push Source and Run Apex Tests
 
-on: [push]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+  
 jobs:
   build:
 
@@ -9,19 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2 #Check out this repo
-      - uses: actions/checkout@v2 #Checkout fflib-apex-mocks as a sibling of this repo
-        with:
-          repository: apex-enterprise-patterns/fflib-apex-mocks
-          path: fflib-apex-mocks
-      - name: Hack the sfdx-project.json to prepend the second package directory for fflib-apex-mocks
-        run: cat sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project2.json
-      - run: mv sfdx-project2.json sfdx-project.json
-      - run: cat sfdx-project.json
       - name: Install SFDX CLI and authorize DevHub
         uses: apex-enterprise-patterns/setup-sfdx@v1 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
       - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
+      - run: echo y | sfdx plugins:install shane-sfdx-plugins
+      - run: sfdx shane:github:src:install -g apex-enterprise-patterns -r fflib-apex-mocks
       - run: sfdx force:org:create -f config/project-scratch-def.json --setdefaultusername -d 1
       - run: sfdx force:source:push
       - run: sfdx force:apex:test:run -w 5

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           repository: apex-enterprise-patterns/fflib-apex-mocks
           path: fflib-apex-mocks
-      - name: Hack the sfdx-project.json to prepend the second package directory
+      - name: Hack the sfdx-project.json to prepend the second package directory for fflib-apex-mocks
         run: echo sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
       - run: cat sfdx-project.json
       - name: Install SFDX CLI and authorize DevHub

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
       - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
-      - run: sfdx force:org:create -f config\project-scratch-def.json --setdefaultusername -d 1
+      - run: sfdx force:org:create -f config/project-scratch-def.json --setdefaultusername -d 1
       - run: sfdx force:source:push
       - run: sfdx force:apex:test:run -w 5
       - name: Destroy scratch org

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -19,7 +19,7 @@ jobs:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
       - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
       - run: echo y | sfdx plugins:install shane-sfdx-plugins
-      - run: sfdx shane:github:src:install -g apex-enterprise-patterns -r fflib-apex-mocks
+      - run: sfdx shane:github:src:install -c -g apex-enterprise-patterns -r fflib-apex-mocks -p sfdx-source/apex-mocks
       - run: sfdx force:org:create -f config/project-scratch-def.json --setdefaultusername -d 1
       - run: sfdx force:source:push
       - run: sfdx force:apex:test:run -w 5

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -19,8 +19,8 @@ jobs:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
       - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
       - run: echo y | sfdx plugins:install shane-sfdx-plugins
-      - run: sfdx shane:github:src:install -c -g apex-enterprise-patterns -r fflib-apex-mocks -p sfdx-source/apex-mocks
       - run: sfdx force:org:create -f config/project-scratch-def.json --setdefaultusername -d 1
+      - run: sfdx shane:github:src:install -c -g apex-enterprise-patterns -r fflib-apex-mocks -p sfdx-source/apex-mocks
       - run: sfdx force:source:push
       - run: sfdx force:apex:test:run -w 5
       - name: Destroy scratch org

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -1,0 +1,28 @@
+name: Create a Scratch Org and run Apex unit tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2 #Check out this repo
+      - uses: actions/checkout@v2 #Checkout fflib-apex-mocks
+        - repository: apex-enterprise-patterns/fflib-apex-mocks
+      - name: Hack the sfdx-project.json to prepend the second package directory
+        run: echo sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
+      - run: cat sfdx-project.json
+      - name: Install SFDX CLI and authorize DevHub
+        uses: sfdx-actions/setup-sfdx@v1 #Might want to consider forking this guy's GH Action repo for safety
+        with:
+          sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
+      - run: sfdx force:config:set defaultdevhubusername=SFDX-ENV -g #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
+      - run: sfdx force:org:create -f config\project-scratch-def.json --setdefaultusername -d 1
+      - run: sfdx force:source:push
+      - run: sfdx force:apex:test:run -w 5
+      - name: Destroy scratch org
+        #Need to read more about a post action -- experimental new feature https://github.community/t5/GitHub-Actions/About-post-in-an-Action/td-p/41973
+        #so that the scratch org gets deleted even if the source push or test run fails so we don't have a pileup of dysfunctional orgs
+        run: sfdx force:org:delete -p

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2 #Check out this repo
       - uses: actions/checkout@v2 #Checkout fflib-apex-mocks
-        - repository: apex-enterprise-patterns/fflib-apex-mocks
+        with:
+          repository: apex-enterprise-patterns/fflib-apex-mocks
+          path: fflib-apex-mocks
       - name: Hack the sfdx-project.json to prepend the second package directory
         run: echo sfdx-project.json | jq '.packageDirectories = [{path:"fflib-apex-mocks/sfdx-source"}] + .packageDirectories' > sfdx-project.json
       - run: cat sfdx-project.json

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -24,6 +24,6 @@ jobs:
       - run: sfdx force:source:push
       - run: sfdx force:apex:test:run -w 5
       - name: Destroy scratch org
-        #Need to read more about a post action -- experimental new feature https://github.community/t5/GitHub-Actions/About-post-in-an-Action/td-p/41973
-        #so that the scratch org gets deleted even if the source push or test run fails so we don't have a pileup of dysfunctional orgs
         run: sfdx force:org:delete -p
+        if: always()
+

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,8 +2,8 @@
     "orgName": "apex-common",
     "edition": "Developer",
     "settings": {
-        "orgPreferenceSettings": {
-            "s1DesktopEnabled": true
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
         }
     }
 }


### PR DESCRIPTION
This is my basic cut at a GH Action Workflow 

Fanc(ier) things that we can add some day:
 * Status badge for the README
 * Orchestration via the GH API to trigger builds in other respositories (https://github.com/apex-enterprise-patterns/fflib-apex-common-samplecode is the one that comes to mind)

