### PR TITLE
Allow for different implementations of Application factories

### DIFF
--- a/docs/Application.md
+++ b/docs/Application.md
@@ -1,0 +1,45 @@
+FFLib Apex Common
+=================
+
+# Application class
+
+### Example - Binding based on static maps in Apex
+
+```apex
+public with sharing class Application
+{
+    public static final fflib_ServiceBindingResolver Service =
+            new fflib_ClassicServiceBindingResolver(
+                    new Map<Type, Type>
+                    {
+                            AccountsService.class => AccountsServiceImp.class
+                    }
+            );
+
+    public static final fflib_SelectorBindingResolver Selector =
+            new fflib_ClassicSelectorBindingResolver(
+                    new Map<SObjectType, Type>
+                    {
+                            Account.SObjectType => AccountsSelector.class
+                    }
+            );
+
+    public static final fflib_DomainBindingResolver Domain =
+            new fflib_ClassicDomainBindingResolver(
+                    Application.Selector,
+                    new Map<SObjectType, Type>
+                    {
+		                    Schema.Account.SObjectType => Accounts.Constructor.class
+                    }
+            );
+
+    public static final fflib_Application.UnitOfWorkFactory UnitOfWork =
+            new fflib_Application.UnitOfWorkFactory(
+                    new List<SObjectType>
+                    {
+                            Account.SObjectType,
+                            Contact.SObjectType
+                    }
+           );
+}
+```

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicDomainBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicDomainBindingResolver.cls
@@ -1,0 +1,129 @@
+/**
+ * File Name: fflib_ClassicDomainBindingResolver
+ * Description: Domain class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ *
+ * @author : architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com
+ */
+public virtual class fflib_ClassicDomainBindingResolver implements fflib_DomainBindingResolver
+{
+	protected fflib_SelectorBindingResolver selectorBindingResolver;
+
+	protected Map<Schema.SObjectType, Type> domainConstructorBySObjectType;
+
+	protected Map<Schema.SObjectType, fflib_ISObjectDomain> mockDomainInstanceBySObjectType;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param selectorBindingResolver
+	 * @param domainConstructorBySObjectType
+	 */
+	public fflib_ClassicDomainBindingResolver(
+			fflib_SelectorBindingResolver selectorBindingResolver,
+			Map<SObjectType, Type> domainConstructorBySObjectType)
+	{
+		this.selectorBindingResolver = selectorBindingResolver;
+		this.domainConstructorBySObjectType = domainConstructorBySObjectType;
+		this.mockDomainInstanceBySObjectType = new Map<SObjectType, fflib_ISObjectDomain>();
+	}
+
+	/**
+	 * Dynamically constructs an instance of a Domain class for the given record Ids
+	 *   Internally uses the Selector Factory to query the records before passing to a
+	 *   dynamically constructed instance of the application Apex Domain class
+	 *
+	 * @param recordIds A list of Id's of the same type
+	 * @exception Throws an exception via the Selector Factory if the Ids are not all of the same SObjectType
+	 *
+	 * @return Instance of fflib_ISObjectDomain containing the record with the provided Ids
+	 **/
+	public virtual fflib_ISObjectDomain newInstance(Set<Id> recordIds)
+	{
+		return newInstance(selectorBindingResolver.selectById(recordIds));
+	}
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A concrete list (e.g. List<Account> vs List<SObject>) of records
+	 * @exception Throws an exception if the SObjectType cannot be determined from the list
+	 *              or the constructor for Domain class was not registered for the SOBjectType
+	 *
+	 * @return Instance of fflib_ISObjectDomain containing the provided records
+	 **/
+	public virtual fflib_ISObjectDomain newInstance(List<SObject> records)
+	{
+		SObjectType domainSObjectType = records.getSObjectType();
+		if (domainSObjectType == null)
+			throw new DeveloperException('Unable to determine SObjectType');
+
+		// Mock implementation?
+		if (mockDomainInstanceBySObjectType.containsKey(domainSObjectType))
+			return mockDomainInstanceBySObjectType.get(domainSObjectType);
+
+		// Determine SObjectType and Apex classes for Domain class
+		Type domainConstructorClass = domainConstructorBySObjectType.get(domainSObjectType);
+		if (domainConstructorClass == null)
+			throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
+
+		// Construct Domain class passing in the queried records
+		fflib_SObjectDomain.IConstructable domainConstructor =
+				(fflib_SObjectDomain.IConstructable) domainConstructorClass.newInstance();
+		return (fflib_ISObjectDomain) domainConstructor.construct(records);
+	}
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records and SObjectType
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A list records
+	 * @param domainSObjectType SObjectType for list of records
+	 * @exception Throws an exception if the SObjectType is not specified or if constructor for Domain class was not registered for the SObjectType
+	 *
+	 * @remark Will support List<SObject> but all records in the list will be assumed to be of
+	 *         the type specified in sObjectType
+	 *
+	 * @return Instance of fflib_ISObjectDomain containing the provided records
+	 **/
+	public virtual fflib_ISObjectDomain newInstance(List<SObject> records, SObjectType domainSObjectType)
+	{
+		if (domainSObjectType == null)
+			throw new DeveloperException('Must specify sObjectType');
+
+		// Mock implementation?
+		if (mockDomainInstanceBySObjectType.containsKey(domainSObjectType))
+			return mockDomainInstanceBySObjectType.get(domainSObjectType);
+
+		// Determine SObjectType and Apex classes for Domain class
+		Type domainConstructorClass = domainConstructorBySObjectType.get(domainSObjectType);
+		if (domainConstructorClass == null)
+			throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
+
+		// Construct Domain class passing in the queried records
+		fflib_SObjectDomain.IConstructable2 domainConstructor =
+				(fflib_SObjectDomain.IConstructable2) domainConstructorClass.newInstance();
+		return (fflib_ISObjectDomain) domainConstructor.construct(records, domainSObjectType);
+	}
+
+	public void replaceWith(SObjectType domainSObjectType, Type domainConstructorImplementationType)
+	{
+		this.domainConstructorBySObjectType.put(domainSObjectType, domainConstructorImplementationType);
+	}
+
+	public virtual void setMock(fflib_ISObjectDomain mockDomain)
+	{
+		setMock(mockDomain.sObjectType(), mockDomain);
+	}
+
+	public virtual void setMock(Schema.SObjectType domainSObjectType, fflib_ISObjectDomain mockDomain)
+	{
+		mockDomainInstanceBySObjectType.put(domainSObjectType, mockDomain);
+	}
+
+	/**
+	 * Exception representing a developer coding error, not intended for end user eyes
+	 **/
+	public class DeveloperException extends Exception {}
+}

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicDomainBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicDomainBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicSelectorBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicSelectorBindingResolver.cls
@@ -1,0 +1,123 @@
+/**
+ * File Name: fflib_ClassicSelectorBindingResolver
+ * Description: Selector class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ *
+ * @author : architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com
+ */
+public virtual class fflib_ClassicSelectorBindingResolver
+		implements fflib_SelectorBindingResolver
+{
+
+	protected Map<SObjectType, Type> selectorImplementationTypeBySObjectType;
+	protected Map<SObjectType, fflib_ISObjectSelector> selectorMockBySObjectType;
+
+	/**
+	 * Class constructor
+	 */
+	public fflib_ClassicSelectorBindingResolver(Map<SObjectType, Type> selectorImplementationTypeBySObjectType)
+	{
+		this.selectorImplementationTypeBySObjectType = selectorImplementationTypeBySObjectType;
+		this.selectorMockBySObjectType = new Map<SObjectType, fflib_ISObjectSelector>();
+	}
+
+	/**
+	 * Creates a new instance of the associated Apex Class implementing fflib_ISObjectSelector
+	 *   for the given SObjectType, or if provided via setMock returns the Mock implementation
+	 *
+	 * @param sObjectType An SObjectType token, e.g. Account.SObjectType
+	 *
+	 * @return Instance of the selector implementation
+	 **/
+	public virtual fflib_ISObjectSelector newInstance(Schema.SObjectType sObjectType)
+	{
+		// Mock implementation?
+		if (selectorMockBySObjectType.containsKey(sObjectType))
+			return selectorMockBySObjectType.get(sObjectType);
+
+		// Determine Apex class for Selector class
+		Type selectorClass = selectorImplementationTypeBySObjectType.get(sObjectType);
+		if (selectorClass == null)
+			throw new DeveloperException('Selector class not found for SObjectType ' + sObjectType);
+
+		// Construct Selector class and query by Id for the records
+		return (fflib_ISObjectSelector) selectorClass.newInstance();
+	}
+
+	/**
+	 * Replaces the linked implementation for the Apex interface.
+	 *
+	 * @param sObjectType The SObjectType for the new implementation
+	 * @param selectorImplementationType The replacement implementation type for the given SObjectType
+	 */
+	public void replaceWith(Schema.SObjectType sObjectType, Type selectorImplementationType)
+	{
+		this.selectorImplementationTypeBySObjectType.put(sObjectType, selectorImplementationType);
+	}
+
+	/**
+	 * Helper method to query the given SObject records
+	 *   Internally creates an instance of the registered Selector and calls its
+	 *     selectSObjectById method
+	 *
+	 * @param recordIds The SObject record Ids, must be all the same SObjectType
+	 *
+	 * @return List of queried SObjects
+	 * @exception Is thrown if the record Ids are not all the same or the SObjectType is not registered
+	 **/
+	public virtual List<SObject> selectById(Set<Id> recordIds)
+	{
+		// No point creating an empty Domain class, nor can we determine the SObjectType anyway
+		if (recordIds == null || recordIds.size() == 0)
+			throw new DeveloperException('Invalid record Id\'s set');
+
+		// Determine SObjectType
+		Schema.SObjectType domainSObjectType = new List<Id>(recordIds)[0].getSobjectType();
+		for (Id recordId : recordIds)
+		{
+			if (recordId.getSobjectType() != domainSObjectType)
+				throw new DeveloperException('Unable to determine SObjectType, Set contains Id\'s from different SObject types');
+		}
+
+		// Construct Selector class and query by Id for the records
+		return newInstance(domainSObjectType).selectSObjectsById(recordIds);
+	}
+
+	/**
+	 * Helper method to query related records to those provided, for example
+	 *   if passed a list of Opportunity records and the Account Id field will
+	 *   construct internally a list of Account Ids and call the registered
+	 *   Account selector to query the related Account records, e.g.
+	 * <p/>
+	 *     List<Account> accounts =
+	 *        (List<Account>) Application.Selector.selectByRelationship(myOpportunities, Opportunity.AccountId);
+	 *
+	 * @param relatedRecords used to extract the related record Ids, e.g. Opportunity records
+	 * @param relationshipField field in the passed records that contains the relationship records to query, e.g. Opportunity.AccountId
+	 *
+	 * @return A list of the queried SObjects
+	 **/
+	public virtual List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField)
+	{
+		Set<Id> relatedIds = new Set<Id>();
+		for (SObject relatedRecord : relatedRecords)
+		{
+			Id relatedId = (Id) relatedRecord.get(relationshipField);
+			if (relatedId != null)
+			{
+				relatedIds.add(relatedId);
+			}
+		}
+		return selectById(relatedIds);
+	}
+
+	public virtual void setMock(fflib_ISObjectSelector selectorInstance)
+	{
+		selectorMockBySObjectType.put(selectorInstance.sObjectType(), selectorInstance);
+	}
+
+	/**
+	 * Exception representing a developer coding error, not intended for end user eyes
+	 **/
+	public class DeveloperException extends Exception {}
+}

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicSelectorBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicSelectorBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicServiceBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicServiceBindingResolver.cls
@@ -1,0 +1,79 @@
+/**
+ * File Name: fflib_ClassicServiceBindingResolver
+ * Description: Service class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ *
+ * @author : architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com
+ */
+public virtual class fflib_ClassicServiceBindingResolver
+		implements fflib_ServiceBindingResolver
+{
+
+	protected Map<Type, Type> implementationTypeByInterfaceType;
+	protected Map<Type, Object> mockImplementationByInterfaceType;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param implementationTypeByInterfaceType A map linking the interface type to its implementation type
+	 */
+	public fflib_ClassicServiceBindingResolver(Map<Type, Type> implementationTypeByInterfaceType)
+	{
+		this.implementationTypeByInterfaceType = implementationTypeByInterfaceType;
+		this.mockImplementationByInterfaceType = new Map<Type, Object>();
+	}
+
+	/**
+	 * Returns a new instance of the Apex class associated with the given Apex interface
+	 *   Will return any mock implementation of the interface provided via setMock
+	 *   Note that this method will not check the configured Apex class actually implements the interface
+	 *
+	 * @param serviceInterfaceType Apex interface type
+	 *
+	 * @return Instance of the implementation type
+	 * @exception DeveloperException Is thrown if there is no registered Apex class for the interface type
+	 **/
+	public virtual Object newInstance(Type serviceInterfaceType)
+	{
+		// Mock implementation?
+		if (mockImplementationByInterfaceType.containsKey(serviceInterfaceType))
+			return mockImplementationByInterfaceType.get(serviceInterfaceType);
+
+		// Create an instance of the type implementing the given interface
+		Type serviceImpl = implementationTypeByInterfaceType.get(serviceInterfaceType);
+		if (serviceImpl == null)
+			throw new DeveloperException('No implementation registered for service interface ' + serviceInterfaceType.getName());
+
+		return serviceImpl.newInstance();
+	}
+
+	/**
+	 * Replaces the linked implementation for the Apex interface.
+	 *
+	 * @param serviceInterfaceType The interface type for this new implementation
+	 * @param serviceImplementationType The replacement implementation type for the given interface type
+	 */
+	public virtual void replaceWith(Type serviceInterfaceType, Type serviceImplementationType)
+	{
+		implementationTypeByInterfaceType.put(serviceInterfaceType, serviceImplementationType);
+	}
+
+	/**
+	 * Replaces the linked implementation for a mocked implementation, used in unit-test
+	 *
+	 * @param serviceInterfaceType The interface type for this new implementation
+	 * @param serviceInstance The mock instance for the given interface type
+	 */
+	public virtual void setMock(Type serviceInterfaceType, Object serviceInstance)
+	{
+		if (!System.Test.isRunningTest())
+			throw new DeveloperException('The setMock method should only be invoked from a unit-test context');
+
+		mockImplementationByInterfaceType.put(serviceInterfaceType, serviceInstance);
+	}
+
+	/**
+	 * Exception representing a developer coding error, not intended for end user eyes
+	 **/
+	public class DeveloperException extends Exception {}
+}

--- a/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicServiceBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/implementation/fflib_ClassicServiceBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/application/classes/interface/fflib_DomainBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_DomainBindingResolver.cls
@@ -1,0 +1,60 @@
+/**
+ * File Name: fflib_DomainBindingResolver 
+ * Description: Interface for resolving domain class bindings
+ * Copyright (c) 2020 Johnson & Johnson
+ * @author: architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com 
+ */
+public interface fflib_DomainBindingResolver
+{
+	/**
+	 * Dynamically constructs an instance of a Domain class for the given record Ids
+	 *   Internally uses the Selector Factory to query the records before passing to a
+	 *   dynamically constructed instance of the application Apex Domain class
+	 *
+	 * @param recordIds A list of Id's of the same type
+	 * @return Instance of fflib_ISObjectDomain containing the record with the provided Ids
+	 **/
+	fflib_ISObjectDomain newInstance(Set<Id> recordIds);
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A concrete list (e.g. List<Account> vs List<SObject>) of records
+	 * @return Instance of fflib_ISObjectDomain containing the provided records
+	 **/
+	fflib_ISObjectDomain newInstance(List<SObject> records);
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records and SObjectType
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A list records
+	 * @param domainSObjectType SObjectType for list of records
+	 **/
+	fflib_ISObjectDomain newInstance(List<SObject> records, SObjectType domainSObjectType);
+
+	/**
+	 * Replaces the linked implementation for the Apex interface.
+	 *
+	 * @param domainSObjectType The interface type for this new implementation
+	 * @param domainConstructorImplementationType The replacement implementation type for the given interface type
+	 *    this should be the domain Constructor which is an implementation of fflib_SObjectDomainConstructor
+	 */
+	void replaceWith(Schema.SObjectType domainSObjectType, Type domainConstructorImplementationType);
+
+	/**
+	 * Replaces the linked implementation for a mocked implementation, used in unit-test
+	 *
+	 * @param mockDomain The mock instance for the given interface type
+	 */
+	void setMock(fflib_ISObjectDomain mockDomain);
+
+	/**
+	 * Replaces the linked implementation for a mocked implementation, used in unit-test
+	 *
+	 * @param domainSObjectType The SObjectType to mock
+	 * @param mockDomain The mock instance for the given interface type
+	 */
+	void setMock(Schema.SObjectType domainSObjectType, fflib_ISObjectDomain mockDomain);
+}

--- a/sfdx-source/apex-common/application/classes/interface/fflib_DomainBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_DomainBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/application/classes/interface/fflib_SelectorBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_SelectorBindingResolver.cls
@@ -1,0 +1,57 @@
+/**
+ * File Name: fflib_SelectorBindingResolver 
+ * Description: Interface for resolving selector class bindings
+ * Copyright (c) 2020 Johnson & Johnson
+ * @author: architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com 
+ */
+public interface fflib_SelectorBindingResolver
+{
+	/**
+	 * Creates a new instance of the associated Apex Class implementing fflib_ISObjectSelector
+	 *   for the given SObjectType, or if provided via setMock returns the Mock implementation
+	 *
+	 * @param sObjectType An SObjectType token, e.g. Account.SObjectType
+	 * @return Instance of the selector implementation
+	 **/
+	fflib_ISObjectSelector newInstance(Schema.SObjectType sObjectType);
+
+	/**
+	 * Replaces the linked implementation for the Apex interface.
+	 *
+	 * @param sObjectType The SObjectType for the new implementation
+	 * @param selectorImplementationType The replacement implementation type for the given SObjectType
+	 */
+	void replaceWith(Schema.SObjectType sObjectType, Type selectorImplementationType);
+
+	/**
+	 * Helper method to query the given SObject records
+	 *   Internally creates an instance of the registered Selector and calls its
+	 *     selectSObjectById method
+	 *
+	 * @param recordIds The SObject record Ids, must be all the same SObjectType
+	 * @return List of queried SObjects
+	 **/
+	List<SObject> selectById(Set<Id> recordIds);
+
+	/**
+	 * Helper method to query related records to those provided, for example
+	 *   if passed a list of Opportunity records and the Account Id field will
+	 *   construct internally a list of Account Ids and call the registered
+	 *   Account selector to query the related Account records, e.g.
+	 *
+	 *     List<Account> accounts =
+	 *        (List<Account>) Application.Selector.selectByRelationship(myOpportunities, Opportunity.AccountId);
+	 *
+	 * @param relatedRecords used to extract the related record Ids, e.g. Opportunity records
+	 * @param relationshipField field in the passed records that contains the relationship records to query, e.g. Opportunity.AccountId
+	 * @return A list of the queried SObjects
+	 **/
+	List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField);
+
+	/**
+	 * Replaces the linked implementation for a mocked implementation, used in unit-test
+	 *
+	 * @param selectorInstance The mock implementation for the given interface type
+	 */
+	void setMock(fflib_ISObjectSelector selectorInstance);
+}

--- a/sfdx-source/apex-common/application/classes/interface/fflib_SelectorBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_SelectorBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/application/classes/interface/fflib_ServiceBindingResolver.cls
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_ServiceBindingResolver.cls
@@ -1,0 +1,32 @@
+/**
+ * File Name: fflib_ServiceBindingResolver 
+ * Description: Interface for resolving service class bindings
+ * Copyright (c) 2020 Johnson & Johnson
+ * @author: architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com 
+ */
+public interface fflib_ServiceBindingResolver
+{
+	/**
+	 * Returns a new instance of the Apex class associated with the given Apex interface
+	 *
+	 * @param serviceInterfaceType Apex interface type
+	 * @return Instance of the implementation type
+	 **/
+	Object newInstance(Type serviceInterfaceType);
+
+	/**
+	 * Replaces the linked implementation for the Apex interface.
+	 *
+	 * @param serviceInterfaceType The interface type for this new implementation
+	 * @param serviceImplementationType The replacement implementation type for the given interface type
+	 */
+	void replaceWith(Type serviceInterfaceType, Type serviceImplementationType);
+
+	/**
+	 * Replaces the linked implementation for a mocked implementation, used in unit-test
+	 *
+	 * @param serviceInterfaceType The interface type for this new implementation
+	 * @param serviceInstance The mock instance for the given interface type
+	 */
+	void setMock(Type serviceInterfaceType, Object serviceInstance);
+}

--- a/sfdx-source/apex-common/application/classes/interface/fflib_ServiceBindingResolver.cls-meta.xml
+++ b/sfdx-source/apex-common/application/classes/interface/fflib_ServiceBindingResolver.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -118,259 +118,242 @@ public virtual class fflib_Application
 	}
 
 	/**
-	 * Simple Service Factory implementation
+	 * DEPRECATED - Simple Service Factory implementation
 	 **/
-	public virtual class ServiceFactory
+	public virtual class ServiceFactory extends Deprecated
 	{
-		protected Map<Type, Type> m_serviceInterfaceTypeByServiceImplType;
-
-		protected Map<Type, Object> m_serviceInterfaceTypeByMockService;
+		protected fflib_ClassicServiceBindingResolver bindingResolver;
 
 		/**
-		 * Constructs a simple Service Factory, 
-		 *   using a Map of Apex Interfaces to Apex Classes implementing the interface
-		 *   Note that this will not check the Apex Classes given actually implement the interfaces
-		 *     as this information is not presently available via the Apex runtime
-		 *
-		 * @param serviceInterfaceTypeByServiceImplType Map ofi interfaces to classes
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public ServiceFactory(Map<Type, Type> serviceInterfaceTypeByServiceImplType)
 		{
-			m_serviceInterfaceTypeByServiceImplType = serviceInterfaceTypeByServiceImplType;
-			m_serviceInterfaceTypeByMockService = new Map<Type, Object>();
+			logDeprecatedMessage('constructor');
+			this.bindingResolver = new fflib_ClassicServiceBindingResolver(serviceInterfaceTypeByServiceImplType);
 		}
 
 		/**
-		 * Returns a new instance of the Apex class associated with the given Apex interface
-		 *   Will return any mock implementation of the interface provided via setMock
-		 *   Note that this method will not check the configured Apex class actually implements the interface
-		 *
-		 * @param serviceInterfaceType Apex interface type
-		 * @exception Is thrown if there is no registered Apex class for the interface type
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public virtual Object newInstance(Type serviceInterfaceType)
 		{
-			// Mock implementation?
-			if(m_serviceInterfaceTypeByMockService.containsKey(serviceInterfaceType))
-				return m_serviceInterfaceTypeByMockService.get(serviceInterfaceType);
-
-			// Create an instance of the type implementing the given interface
-			Type serviceImpl = m_serviceInterfaceTypeByServiceImplType.get(serviceInterfaceType);
-			if(serviceImpl==null)
-				throw new DeveloperException('No implementation registered for service interface ' + serviceInterfaceType.getName());	
-			return serviceImpl.newInstance();
+			logDeprecatedMessage('newInstance');
+			try
+			{
+				return bindingResolver.newInstance(serviceInterfaceType);
+			} catch (fflib_ClassicServiceBindingResolver.DeveloperException e)
+			{
+				throw new DeveloperException(e.getMessage());
+			}
 		}
 
+		/**
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
+		 **/
 		@TestVisible
 		private virtual void setMock(Type serviceInterfaceType, Object serviceImpl)
 		{
-			m_serviceInterfaceTypeByMockService.put(serviceInterfaceType, serviceImpl);
+			logDeprecatedMessage('setMock');
+			bindingResolver.setMock(serviceInterfaceType, serviceImpl);
+		}
+
+		private void logDeprecatedMessage(String methodName)
+		{
+			logDeprecatedMessage(
+					'ServiceFactory',
+					methodName,
+					'fflib_ServiceBindingResolver'
+			);
 		}
 	}
 
 	/**
-	 * Class implements a Selector class factory
+	 * DEPRECATED - Simple Service Factory implementation
 	 **/
-	public virtual class SelectorFactory
+	public virtual class SelectorFactory extends Deprecated
 	{
-		protected Map<SObjectType, Type> m_sObjectBySelectorType;
-		protected Map<SObjectType, fflib_ISObjectSelector> m_sObjectByMockSelector;
+		fflib_ClassicSelectorBindingResolver bindingResolver;
 
 		/**
-		 * Consturcts a Selector Factory linking SObjectType's with Apex Classes implement the fflib_ISObjectSelector interface
-		 *   Note that the factory does not check the given Apex Classes implement the interface
-		 *     currently this is not possible in Apex.
-		 *
-		 * @Param sObjectBySelectorType Map of SObjectType's to Selector Apex Classes
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public SelectorFactory(Map<SObjectType, Type> sObjectBySelectorType)
 		{
-			m_sObjectBySelectorType = sObjectBySelectorType;
-			m_sObjectByMockSelector = new Map<SObjectType, fflib_ISObjectSelector>();		
+			logDeprecatedMessage('constructor');
+			this.bindingResolver = new fflib_ClassicSelectorBindingResolver(sObjectBySelectorType);
 		}
 
 		/**
-		 * Creates a new instance of the associated Apex Class implementing fflib_ISObjectSelector
-		 *   for the given SObjectType, or if provided via setMock returns the Mock implementation
-		 *
-		 * @param sObjectType An SObjectType token, e.g. Account.SObjectType
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
-		public virtual fflib_ISObjectSelector newInstance(SObjectType sObjectType)
+		public virtual fflib_ISObjectSelector newInstance(Schema.SObjectType sObjectType)
 		{
-			// Mock implementation?
-			if(m_sObjectByMockSelector.containsKey(sObjectType))
-				return m_sObjectByMockSelector.get(sObjectType);
-
-			// Determine Apex class for Selector class			
-			Type selectorClass = m_sObjectBySelectorType.get(sObjectType);
-			if(selectorClass==null)
-				throw new DeveloperException('Selector class not found for SObjectType ' + sObjectType);
-
-			// Construct Selector class and query by Id for the records
-			return (fflib_ISObjectSelector) selectorClass.newInstance();			
+			logDeprecatedMessage('newInstance');
+			return bindingResolver.newInstance(sObjectType);
 		}
 
 		/**
-		 * Helper method to query the given SObject records
-		 *   Internally creates an instance of the registered Selector and calls its
-		 *     selectSObjectById method
-		 *
-		 * @param recordIds The SObject record Ids, must be all the same SObjectType
-		 * @exception Is thrown if the record Ids are not all the same or the SObjectType is not registered
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public List<SObject> selectById(Set<Id> recordIds)
 		{
-			// No point creating an empty Domain class, nor can we determine the SObjectType anyway
-			if(recordIds==null || recordIds.size()==0)
-				throw new DeveloperException('Invalid record Id\'s set');	
-
-			// Determine SObjectType
-			SObjectType domainSObjectType = new List<Id>(recordIds)[0].getSObjectType();
-			for(Id recordId : recordIds)
-				if(recordId.getSobjectType()!=domainSObjectType)
-					throw new DeveloperException('Unable to determine SObjectType, Set contains Id\'s from different SObject types');	
-
-			// Construct Selector class and query by Id for the records
-			return newInstance(domainSObjectType).selectSObjectsById(recordIds);
+			logDeprecatedMessage('selectById');
+			return bindingResolver.selectById(recordIds);
 		}
 
 		/**
-		 * Helper method to query related records to those provided, for example
-		 *   if passed a list of Opportunity records and the Account Id field will
-		 *   construct internally a list of Account Ids and call the registered 
-		 *   Account selector to query the related Account records, e.g.
-		 *
-		 *     List<Account> accounts = 
-		 *        (List<Account>) Application.Selector.selectByRelationship(myOpps, Opportunity.AccountId);
-		 *
-		 * @param relatedRecords used to extract the related record Ids, e.g. Opportunity records
-		 * @param relationshipField field in the passed records that contains the relationship records to query, e.g. Opportunity.AccountId
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField)
 		{
-			Set<Id> relatedIds = new Set<Id>();
-			for(SObject relatedRecord : relatedRecords)
-			{
-				Id relatedId = (Id) relatedRecord.get(relationshipField);
-				if(relatedId!=null)
-					relatedIds.add(relatedId);
-			}
-			return selectById(relatedIds);
+			logDeprecatedMessage('selectById');
+			return bindingResolver.selectByRelationship(relatedRecords, relationshipField);
 		}
 
-		@TestVisible
-		private virtual void setMock(fflib_ISObjectSelector selectorInstance)
+		/**
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
+		 **/
+		public virtual void setMock(fflib_ISObjectSelector selectorInstance)
 		{
-			m_sObjectByMockSelector.put(selectorInstance.sObjectType(), selectorInstance);
-		} 
+			logDeprecatedMessage('setMock');
+			bindingResolver.setMock(selectorInstance);
+		}
+
+		/**
+		 * Added for backwards compatibility, used by the DomainFactory
+		 */
+		private fflib_SelectorBindingResolver getBindingResolver()
+		{
+			return this.bindingResolver;
+		}
+
+		private void logDeprecatedMessage(String methodName)
+		{
+			logDeprecatedMessage(
+					'SelectorFactory',
+					methodName,
+					'fflib_SelectorBindingResolver'
+			);
+		}
 	}
 
 	/**
-	 * Class implements a Domain class factory
+	 * DEPRECATED
+	 * Method kept for backwards compatibility with AEP 1.0
+	 * It should no longer be used as it will be removed in a future version over AEP 2.0
 	 **/
-	public virtual class DomainFactory
+	public virtual class DomainFactory extends Deprecated
 	{
-		protected fflib_Application.SelectorFactory m_selectorFactory;
-
-		protected Map<SObjectType, Type> m_sObjectByDomainConstructorType;
-
-		protected Map<SObjectType, fflib_ISObjectDomain> m_sObjectByMockDomain;
+		fflib_ClassicDomainBindingResolver bindingResolver;
 
 		/**
-		 * Constructs a Domain factory, using an instance of the Selector Factory
-		 *   and a map of Apex classes implementing fflib_ISObjectDomain by SObjectType
-		 *   Note this will not check the Apex classes provided actually implement the interfaces
-		 *     since this is not possible in the Apex runtime at present
-		 *
-		 * @param selectorFactory, e.g. Application.Selector
-		 * @param sObjectByDomainConstructorType Map of Apex classes by SObjectType
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
-		public DomainFactory(fflib_Application.SelectorFactory selectorFactory,
-			Map<SObjectType, Type> sObjectByDomainConstructorType)
+		public DomainFactory(
+				fflib_Application.SelectorFactory selectorFactory,
+				Map<SObjectType, Type> sObjectByDomainConstructorType)
 		{
-			m_selectorFactory = selectorFactory;
-			m_sObjectByDomainConstructorType = sObjectByDomainConstructorType;
-			m_sObjectByMockDomain = new Map<SObjectType, fflib_ISObjectDomain>();
-		}			
+			logDeprecatedMessage('Constructor');
+			this.bindingResolver = new fflib_ClassicDomainBindingResolver(
+					selectorFactory.getBindingResolver(),
+					sObjectByDomainConstructorType
+			);
+		}
 
 		/**
-		 * Dynamically constructs an instance of a Domain class for the given record Ids
-		 *   Internally uses the Selector Factory to query the records before passing to a
-		 *   dynamically constructed instance of the application Apex Domain class
-		 *
-		 * @param recordIds A list of Id's of the same type
-		 * @exception Throws an exception via the Selector Factory if the Ids are not all of the same SObjectType
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public virtual fflib_ISObjectDomain newInstance(Set<Id> recordIds)
 		{
-			return newInstance(m_selectorFactory.selectById(recordIds));
-
-		}	
+			logDeprecatedMessage('newInstance(Set<Id>)');
+			return bindingResolver.newInstance(recordIds);
+		}
 
 		/**
-		 * Dynamically constructs an instance of the Domain class for the given records
-		 *   Will return a Mock implementation if one has been provided via setMock
-		 *
-		 * @param records A concrete list (e.g. List<Account> vs List<SObject>) of records
-		 * @exception Throws an exception if the SObjectType cannot be determined from the list 
-		 *              or the constructor for Domain class was not registered for the SObjectType
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public virtual fflib_ISObjectDomain newInstance(List<SObject> records)
 		{
-			SObjectType domainSObjectType = records.getSObjectType();
-			if(domainSObjectType==null)
-				throw new DeveloperException('Unable to determine SObjectType');
-
-			// Mock implementation?
-			if(m_sObjectByMockDomain.containsKey(domainSObjectType))
-				return m_sObjectByMockDomain.get(domainSObjectType);
-
-			// Determine SObjectType and Apex classes for Domain class
-			Type domainConstructorClass = m_sObjectByDomainConstructorType.get(domainSObjectType);
-			if(domainConstructorClass==null)
-				throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
-
-			// Construct Domain class passing in the queried records
-			fflib_SObjectDomain.IConstructable domainConstructor = 
-				(fflib_SObjectDomain.IConstructable) domainConstructorClass.newInstance();		
-			return (fflib_ISObjectDomain) domainConstructor.construct(records);
-		}	
+			logDeprecatedMessage('newInstance(Set<Id>)');
+			return bindingResolver.newInstance(records);
+		}
 
 		/**
-		 * Dynamically constructs an instance of the Domain class for the given records and SObjectType
-		 *   Will return a Mock implementation if one has been provided via setMock
-		 *
-		 * @param records A list records
-		 * @param domainSObjectType SObjectType for list of records
-		 * @exception Throws an exception if the SObjectType is not specified or if constructor for Domain class was not registered for the SObjectType
-		 *
-		 * @remark Will support List<SObject> but all records in the list will be assumed to be of
-		 *         the type specified in sObjectType
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
 		 **/
 		public virtual fflib_ISObjectDomain newInstance(List<SObject> records, SObjectType domainSObjectType)
 		{
-			if(domainSObjectType==null)
-				throw new DeveloperException('Must specify sObjectType');
-
-			// Mock implementation?
-			if(m_sObjectByMockDomain.containsKey(domainSObjectType))
-				return m_sObjectByMockDomain.get(domainSObjectType);
-
-			// Determine SObjectType and Apex classes for Domain class
-			Type domainConstructorClass = m_sObjectByDomainConstructorType.get(domainSObjectType);
-			if(domainConstructorClass==null)
-				throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
-
-			// Construct Domain class passing in the queried records
-			fflib_SObjectDomain.IConstructable2 domainConstructor = 
-				(fflib_SObjectDomain.IConstructable2) domainConstructorClass.newInstance();
-			return (fflib_ISObjectDomain) domainConstructor.construct(records, domainSObjectType);
+			logDeprecatedMessage('newInstance(Set<Id>)');
+			return bindingResolver.newInstance(records, domainSObjectType);
 		}
 
+		/**
+		 * DEPRECATED
+		 * Method kept for backwards compatibility with AEP 1.0
+		 * It should no longer be used as it will be removed in a future version over AEP 2.0
+		 **/
 		@TestVisible
 		private virtual void setMock(fflib_ISObjectDomain mockDomain)
 		{
-			m_sObjectByMockDomain.put(mockDomain.sObjectType(), mockDomain);			
+			logDeprecatedMessage('setMock');
+			this.bindingResolver.setMock(mockDomain);
+		}
+
+		private void logDeprecatedMessage(String methodName)
+		{
+			logDeprecatedMessage(
+					'DomainFactory',
+					methodName,
+					'fflib_DomainBindingResolver'
+			);
+		}
+	}
+
+	private virtual class Deprecated
+	{
+		protected void logDeprecatedMessage(
+				String deprecatedClassName,
+				String methodName,
+				String replacementClassName)
+		{
+			System.debug(
+					System.LoggingLevel.WARN,
+					String.format(
+							'Use of the method fflib_Application.{0}.{1} is deprecated in AEP 2.0,'
+									+ ' use an implementation of {2}',
+							new List<String>
+							{
+									deprecatedClassName,
+									methodName,
+									replacementClassName
+							}
+					)
+			);
 		}
 	}
 

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicDomainBindingResolverTest.cls
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicDomainBindingResolverTest.cls
@@ -1,0 +1,165 @@
+/**
+ * File Name: fflib_ClassicDomainBindingResolverTest
+ * Description: Unit test class for the Domain class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ *
+ * @author : architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com
+ */
+@IsTest
+private class fflib_ClassicDomainBindingResolverTest
+{
+	@IsTest
+	static void itShouldReturnTheDomainInstance()
+	{
+		// GIVEN a configured domain binding resolver with an implementation linked to a SObjectType
+		fflib_ClassicDomainBindingResolver domain = generateConfiguredBindingResolver();
+		List<Account> records = generateAccounts();
+
+		// WHEN we request an instance for the SObjectType
+		fflib_ISObjectDomain result = domain.newInstance(records);
+
+		// THEN the result should be an instance of the Accounts domain class containing the records
+		System.assert(
+				result instanceof Accounts,
+				'Incorrect implementation returned'
+		);
+		System.assert(
+				((List<Account>) result.getRecords()).equals(records),
+				'Returned instance does not contain the right records'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheDomainInstance_DeveloperException_UnknownSObjectType()
+	{
+		// GIVEN a configured domain binding resolver with an implementation linked to a SObjectType
+		//   and an list of an unknown SObjectType
+		fflib_ClassicDomainBindingResolver bindingResolver = generateConfiguredBindingResolver();
+		List<SObject> records = new List<SObject>();
+
+		// WHEN a domain is requested with a list of an unregistered SObjectType
+		Boolean exceptionThrown = false;
+		try
+		{
+			fflib_ISObjectDomain domain = bindingResolver.newInstance(records);
+		}
+		catch (fflib_ClassicDomainBindingResolver.DeveloperException e)
+		{
+			exceptionThrown = true;
+			System.assertEquals(
+					'Unable to determine SObjectType',
+					e.getMessage(),
+					'Incorrect returned exception message'
+			);
+		}
+
+		// THEN an developer exception should have been thrown
+		System.assert(exceptionThrown, 'Expected a fflib_ClassicDomainBindingResolver.DeveloperException');
+	}
+
+	@IsTest
+	static void itShouldReturnTheDomainInstance_DeveloperException_BindingNotFound()
+	{
+		// GIVEN a configured domain binding resolver with an implementation linked to a SObjectType
+		//   and an list of an unregistered SObjectType
+		fflib_ClassicDomainBindingResolver bindingResolver = generateConfiguredBindingResolver();
+		List<Contact> contacts = new List<Contact>();
+
+		// WHEN a domain is requested with a list of an unregistered SObjectType
+		Boolean exceptionThrown = false;
+		try
+		{
+			fflib_ISObjectDomain domain = bindingResolver.newInstance(contacts);
+		}
+		catch (fflib_ClassicDomainBindingResolver.DeveloperException e)
+		{
+			exceptionThrown = true;
+			System.assertEquals(
+					'Domain constructor class not found for SObjectType Contact',
+					e.getMessage(),
+					'Incorrect returned exception message'
+			);
+		}
+
+		// THEN an developer exception should have been thrown
+		System.assert(exceptionThrown, 'Expected a fflib_ClassicDomainBindingResolver.DeveloperException');
+	}
+
+	@IsTest
+	static void itShouldReturnTheMockDomainInstance()
+	{
+		// GIVEN a configured domain binding resolver with an implementation linked to a SObjectType
+		//   and the implementation is mocked
+		fflib_ClassicDomainBindingResolver bindingResolver = generateConfiguredBindingResolver();
+		bindingResolver.setMock(new AccountsMock(generateAccounts()));
+
+		// WHEN a domain is requested
+		fflib_ISObjectDomain result = bindingResolver.newInstance(generateAccounts());
+
+		// THEN the mocked instance should be returned
+		System.assert(result instanceof AccountsMock, 'Expected mock instance');
+	}
+
+
+	private static fflib_ClassicDomainBindingResolver generateConfiguredBindingResolver()
+	{
+		fflib_ClassicSelectorBindingResolver selectorBindingResolver =
+				fflib_ClassicSelectorBindingResolverTest.generateConfiguredSelectorBindingResolver();
+		fflib_ClassicSelectorBindingResolverTest.AccountsSelectorMock selectorMock = new fflib_ClassicSelectorBindingResolverTest.AccountsSelectorMock();
+		selectorBindingResolver.setMock(selectorMock);
+		selectorMock.records = generateAccounts();
+		return generateConfiguredBindingResolver(selectorBindingResolver);
+	}
+
+	private static fflib_ClassicDomainBindingResolver generateConfiguredBindingResolver(
+			fflib_ClassicSelectorBindingResolver selectorBindingResolver
+	)
+	{
+		return new fflib_ClassicDomainBindingResolver(
+				selectorBindingResolver,
+				new Map<SObjectType, Type>
+				{
+						Schema.Account.SObjectType => AccountsConstructor.class
+				}
+		);
+	}
+
+	private static List<Account> generateAccounts()
+	{
+		return new List<Account>
+		{
+				new Account(Id = fflib_IDGenerator.generate(Schema.Account.SObjectType), Name = 'Test A'),
+				new Account(Id = fflib_IDGenerator.generate(Schema.Account.SObjectType), Name = 'Test B'),
+				new Account(Id = fflib_IDGenerator.generate(Schema.Account.SObjectType), Name = 'Test C')
+		};
+	}
+
+	private with sharing class Accounts extends fflib_SObjectDomain
+	{
+		public Accounts(List<SObject> records)
+		{
+			super(records, Schema.Account.SObjectType);
+		}
+	}
+
+	private with sharing class AccountsMock extends fflib_SObjectDomain
+	{
+		public AccountsMock(List<SObject> records)
+		{
+			super(records, Schema.Account.SObjectType);
+		}
+	}
+
+	private class AccountsConstructor implements fflib_SObjectDomain.IConstructable2
+	{
+		public fflib_SObjectDomain construct(List<SObject> sObjectList, SObjectType sObjectType)
+		{
+			return new Accounts(sObjectList);
+		}
+
+		public fflib_SObjectDomain construct(List<SObject> sObjectList)
+		{
+			return new Accounts(sObjectList);
+		}
+	}
+}

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicDomainBindingResolverTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicDomainBindingResolverTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicSelectorBindingResolverTest.cls
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicSelectorBindingResolverTest.cls
@@ -1,0 +1,168 @@
+/**
+ * File Name: fflib_ClassicSelectorBindingResolverTest 
+ * Description: Unit test class for the Selector class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ * @author: architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com 
+ */
+@IsTest
+public class fflib_ClassicSelectorBindingResolverTest
+{
+	@IsTest
+	static void itShouldReturnTheSelectorInstance()
+	{
+		// GIVEN a configured selector binding resolver with an implementation linked to a SObjectType
+		fflib_ClassicSelectorBindingResolver selector = generateConfiguredSelectorBindingResolver();
+
+		// WHEN we request an instance for the SObjectType
+		fflib_ISObjectSelector result = selector.newInstance(Schema.Account.SObjectType);
+
+		// THEN the result should be an instance of the AccountsSelector
+		System.assert(
+				result instanceof AccountsSelector,
+				'Incorrect implementation returned'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheImplementation_NoImplementationRegisteredException()
+	{
+		// GIVEN an empty selector binding resolver
+		fflib_ClassicSelectorBindingResolver selector =
+				new fflib_ClassicSelectorBindingResolver(new Map<Schema.SObjectType, Type> {});
+
+		// WHEN we request an instance for the SObjectType
+		Boolean exceptionThrown = false;
+		try
+		{
+			selector.newInstance(Schema.Account.SObjectType);
+		} catch (fflib_ClassicSelectorBindingResolver.DeveloperException e)
+		{
+			exceptionThrown = true;
+		}
+
+		// THEN an exception should have been thrown
+		System.assert(
+				exceptionThrown,
+				'An exception should have been thrown as the requested SObjectType mapping is not present'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheMockInstance()
+	{
+		// GIVEN a configured service binding resolver with an interface linked to an implementation
+		//    where the linked implementation for the SObjectType has been replaced with a mock
+		fflib_SelectorBindingResolver selector = generateConfiguredSelectorBindingResolver();
+
+		selector.setMock(new AccountsSelectorMock());
+
+		// WHEN we request an instance for the SObjectType
+		fflib_ISObjectSelector result = selector.newInstance(Schema.Account.SObjectType);
+
+		// THEN the result should be the AccountsSelectorMock instance
+		System.assert(
+				result instanceof AccountsSelectorMock,
+				'Incorrect instance returned'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheReplacedImplementation()
+	{
+		// GIVEN a configured service binding resolver with an interface linked to an implementation
+		//   where the implementation is replaced for an alternative implementation
+		fflib_SelectorBindingResolver selector = generateConfiguredSelectorBindingResolver();
+		selector.replaceWith(Schema.Account.SObjectType, AccountsSelectorMock.class);
+
+		// WHEN we request the implementation for the interface
+		fflib_ISObjectSelector result = selector.newInstance(Schema.Account.SObjectType);
+
+		// THEN it should return the alternative implementation
+		System.assert(
+				result instanceof AccountsSelectorMock,
+				'Incorrect implementation returned, expected the alternative implementation'
+		);
+	}
+
+	@IsTest
+	static void itShouldQueryTheRecords()
+	{
+		// GIVEN a configured Selector binding resolver
+		fflib_ClassicSelectorBindingResolver selector = new fflib_ClassicSelectorBindingResolver(
+				new Map<SObjectType, Type>
+				{
+						Schema.Account.SObjectType => AccountsSelectorMock.class
+				}
+		);
+		Id accountId = fflib_IDGenerator.generate(Schema.Account.SObjectType);
+		AccountsSelectorMock selectorMock = new AccountsSelectorMock();
+		selectorMock.records = new List<Account> {new Account(Id = accountId, Name = 'Test')};
+		selector.setMock(selectorMock);
+
+		// WHEN we request the records from the selector resolver
+		List<SObject> result = selector.selectById(new Set<Id>{ accountId });
+
+		// THEN the records should be returned
+		System.assert(selectorMock.records.equals(result));
+	}
+
+	@TestVisible
+	private static fflib_ClassicSelectorBindingResolver generateConfiguredSelectorBindingResolver()
+	{
+		return new fflib_ClassicSelectorBindingResolver(
+				new Map<SObjectType, Type>
+				{
+						Schema.Account.SObjectType => AccountsSelector.class
+				}
+		);
+	}
+
+	public class AccountsSelector extends fflib_SObjectSelector
+	{
+		public List<Schema.SObjectField> getSObjectFieldList()
+		{
+			return new List<Schema.SObjectField>
+			{
+					Account.Id,
+					Account.AccountNumber,
+					Account.Name,
+					Account.Phone
+			};
+		}
+
+		public Schema.SObjectType getSObjectType()
+		{
+			return Schema.Account.SObjectType;
+		}
+
+		public List<Account> selectById(Set<Id> idSet)
+		{
+			return (List<Account>) selectSObjectsById(idSet);
+		}
+	}
+
+	public class AccountsSelectorMock extends fflib_SObjectSelector
+	{
+		public List<Account> records;
+
+		public List<Schema.SObjectField> getSObjectFieldList()
+		{
+			return new List<Schema.SObjectField> {};
+		}
+
+		public Schema.SObjectType getSObjectType()
+		{
+			return Schema.Account.SObjectType;
+		}
+
+		public override List<SObject> selectSObjectsById(Set<Id> idSet)
+		{
+			return selectById(idSet);
+		}
+
+		public List<Account> selectById(Set<Id> idSet)
+		{
+			return records;
+		}
+	}
+}

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicSelectorBindingResolverTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicSelectorBindingResolverTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicServiceBindingResolverTest.cls
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicServiceBindingResolverTest.cls
@@ -1,0 +1,112 @@
+/**
+ * File Name: fflib_ClassicServiceBindingResolverTest 
+ * Description: Unit test class for the Service class binding resolver based on the classic AEP 1.0 definition with static maps
+ * Copyright (c) 2020 Johnson & Johnson
+ * @author: architect ir. Wilhelmus G.J. Velzeboer | wvelzebo@its.jnj.com 
+ */
+@IsTest
+private class fflib_ClassicServiceBindingResolverTest
+{
+	@IsTest
+	static void itShouldReturnTheServiceInstance()
+	{
+		// GIVEN a configured service binding resolver with an interface linked to an implementation
+		fflib_ServiceBindingResolver service = generateConfiguredServiceBindingResolver();
+
+		// WHEN we request the implementation for the interface
+		Object result = service.newInstance(ServiceInterface.class);
+
+		// THEN the result should be the instance of the fflib_TestServiceInterface
+		System.assert(
+				result instanceof ServiceImplementation,
+				'Incorrect implementation returned'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheInstance_NoImplementationRegisteredException()
+	{
+		// GIVEN an empty service binding resolver
+		fflib_ServiceBindingResolver service =
+				new fflib_ClassicServiceBindingResolver(new Map<Type, Type>	{});
+
+		// WHEN we request an instance of the implementation for the interface
+		Boolean exceptionThrown = false;
+		try
+		{
+			service.newInstance(ServiceInterface.class);
+		} catch (fflib_ClassicServiceBindingResolver.DeveloperException e)
+		{
+			exceptionThrown = true;
+		}
+
+		// THEN an exception should have been thrown
+		System.assert(
+				exceptionThrown,
+				'An exception should have been thrown as the requested interface is not present'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheMockInstance()
+	{
+		// GIVEN a configured service binding resolver with an interface linked to an implementation
+		//    where the interface has been replaced with a mock
+		fflib_ServiceBindingResolver service = generateConfiguredServiceBindingResolver();
+
+
+		service.setMock(ServiceInterface.class, new AlternativeServiceImplementation());
+
+		// WHEN we request an instance for the interface
+		ServiceInterface result = (ServiceInterface) service.newInstance(ServiceInterface.class);
+
+		// THEN the result should be the mock instance of the type fflib_TestServiceInterface
+		System.assert(
+				result instanceof AlternativeServiceImplementation,
+				'Incorrect implementation returned'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnTheReplacedImplementation()
+	{
+		// GIVEN a configured service binding resolver with an interface linked to an implementation
+		//   where the implementation is replaced for an alternative implementation
+		fflib_ServiceBindingResolver service = generateConfiguredServiceBindingResolver();
+		service.replaceWith(ServiceInterface.class, AlternativeServiceImplementation.class);
+
+		// WHEN we request the implementation for the interface
+		ServiceInterface result = (ServiceInterface) service.newInstance(ServiceInterface.class);
+
+		// THEN it should return the alternative implementation
+		System.assert(
+				result instanceof AlternativeServiceImplementation,
+				'Incorrect implementation returned, expected the alternative implementation'
+		);
+	}
+
+	private static fflib_ClassicServiceBindingResolver generateConfiguredServiceBindingResolver()
+	{
+		return new fflib_ClassicServiceBindingResolver(
+				new Map<Type, Type>
+				{
+						ServiceInterface.class => ServiceImplementation.class
+				}
+		);
+	}
+
+	interface ServiceInterface
+	{
+		void myMethod();
+	}
+
+	class ServiceImplementation implements ServiceInterface
+	{
+		public void myMethod(){}
+	}
+
+	class AlternativeServiceImplementation implements ServiceInterface
+	{
+		public void myMethod(){}
+	}
+}

--- a/sfdx-source/apex-common/test/classes/application/fflib_ClassicServiceBindingResolverTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/application/fflib_ClassicServiceBindingResolverTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
@@ -146,7 +146,7 @@ private class fflib_ApplicationTest
 		try {
 			Domain.newInstance(new List<SObject>());
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicDomainBindingResolver.DeveloperException e) {
 			System.assertEquals('Unable to determine SObjectType', e.getMessage());
 		}
 	}
@@ -157,7 +157,7 @@ private class fflib_ApplicationTest
 		try {
 			Domain.newInstance(new List<SObject>(), null);
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicDomainBindingResolver.DeveloperException e) {
 			System.assertEquals('Must specify sObjectType', e.getMessage());
 		}
 	}	
@@ -168,14 +168,14 @@ private class fflib_ApplicationTest
 		try {
 			Domain.newInstance(new List<Product2>{ new Product2(Name = 'Test Product') });
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicDomainBindingResolver.DeveloperException e) {
 			System.assertEquals('Domain constructor class not found for SObjectType Product2', e.getMessage());
 		}
 
 		try {
 			Domain.newInstance(new List<SObject>{ new Product2(Name = 'Test Product') }, Product2.SObjectType);
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicDomainBindingResolver.DeveloperException e) {
 			System.assertEquals('Domain constructor class not found for SObjectType Product2', e.getMessage());
 		}		
 	}
@@ -256,7 +256,7 @@ private class fflib_ApplicationTest
 		try {
 			Selector.newInstance(User.SObjectType);
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicSelectorBindingResolver.DeveloperException e) {
 			System.assertEquals('Selector class not found for SObjectType User', e.getMessage());
 		}
 	}
@@ -267,13 +267,13 @@ private class fflib_ApplicationTest
 		try {
 			Selector.selectById(null);
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicSelectorBindingResolver.DeveloperException e) {
 			System.assertEquals('Invalid record Id\'s set', e.getMessage());
 		}
 		try {
 			Selector.selectById(new Set<Id>());
 			System.assert(false, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicSelectorBindingResolver.DeveloperException e) {
 			System.assertEquals('Invalid record Id\'s set', e.getMessage());
 		}
 	}
@@ -287,7 +287,7 @@ private class fflib_ApplicationTest
 					fflib_IDGenerator.generate(Opportunity.SObjectType), 
 					fflib_IDGenerator.generate(Account.SObjectType) });
 			System.assert(true, 'Expected exception');
-		} catch (fflib_Application.DeveloperException e) {
+		} catch (fflib_ClassicSelectorBindingResolver.DeveloperException e) {
 			System.assertEquals('Unable to determine SObjectType, Set contains Id\'s from different SObject types', e.getMessage());
 		}		
 	}


### PR DESCRIPTION
This PR is to create the possibility for different implementations of the Application factories.
It is fully backwards compatible with the static maps, as methods are replaced and directing to the new classes while showing a deprecated message with instruction on refactoring to the new classes.

This change is mainly done to allow for an implementation similar to force-di, or even make a direct link to it so that fflib can be used in combination with force-di.

The code is not yet entirely finished, but I mainly raised it now to open up the discussion to see the response on this idea.