### PR TITLE
Add new Domain structure

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -272,9 +272,26 @@ public virtual class fflib_Application
 	{
 		protected fflib_Application.SelectorFactory m_selectorFactory;
 
-		protected Map<SObjectType, Type> m_sObjectByDomainConstructorType;
+		protected Map<Object, Type> constructorTypeByObject;
 
-		protected Map<SObjectType, fflib_ISObjectDomain> m_sObjectByMockDomain;
+		protected Map<Object, fflib_IDomain> mockDomainByObject;
+
+		/**
+		 * Constructs a Domain factory, using an instance of the Selector Factory
+		 *   and a map of Apex classes implementing fflib_ISObjectDomain by SObjectType
+		 *   Note this will not check the Apex classes provided actually implement the interfaces
+		 *     since this is not possible in the Apex runtime at present
+		 *
+		 * @param selectorFactory , e.g. Application.Selector
+		 * @param constructorTypeByObject Map of Domain classes by ObjectType
+		 **/
+		public DomainFactory(fflib_Application.SelectorFactory selectorFactory,
+			Map<Object, Type> constructorTypeByObject)
+		{
+			m_selectorFactory = selectorFactory;
+			this.constructorTypeByObject = constructorTypeByObject;
+			this.mockDomainByObject = new Map<Object, fflib_IDomain>();
+		}
 
 		/**
 		 * Constructs a Domain factory, using an instance of the Selector Factory
@@ -289,9 +306,9 @@ public virtual class fflib_Application
 			Map<SObjectType, Type> sObjectByDomainConstructorType)
 		{
 			m_selectorFactory = selectorFactory;
-			m_sObjectByDomainConstructorType = sObjectByDomainConstructorType;
-			m_sObjectByMockDomain = new Map<SObjectType, fflib_ISObjectDomain>();
-		}			
+			this.constructorTypeByObject = getConstructorTypeByObject(sObjectByDomainConstructorType);
+			this.mockDomainByObject = new Map<Object, fflib_IDomain>();
+		}
 
 		/**
 		 * Dynamically constructs an instance of a Domain class for the given record Ids
@@ -301,40 +318,60 @@ public virtual class fflib_Application
 		 * @param recordIds A list of Id's of the same type
 		 * @exception Throws an exception via the Selector Factory if the Ids are not all of the same SObjectType
 		 **/
-		public virtual fflib_ISObjectDomain newInstance(Set<Id> recordIds)
+		public virtual fflib_IDomain newInstance(Set<Id> recordIds)
 		{
 			return newInstance(m_selectorFactory.selectById(recordIds));
 
-		}	
+		}
 
 		/**
 		 * Dynamically constructs an instance of the Domain class for the given records
 		 *   Will return a Mock implementation if one has been provided via setMock
 		 *
 		 * @param records A concrete list (e.g. List<Account> vs List<SObject>) of records
-		 * @exception Throws an exception if the SObjectType cannot be determined from the list 
+		 * @exception Throws an exception if the SObjectType cannot be determined from the list
 		 *              or the constructor for Domain class was not registered for the SObjectType
 		 **/
-		public virtual fflib_ISObjectDomain newInstance(List<SObject> records)
+		public virtual fflib_IDomain newInstance(List<SObject> records)
 		{
 			SObjectType domainSObjectType = records.getSObjectType();
 			if(domainSObjectType==null)
 				throw new DeveloperException('Unable to determine SObjectType');
 
+			return newInstance((List<Object>) records, (Object) domainSObjectType);
+		}
+
+		public virtual fflib_IDomain newInstance(List<Object> objects, Object objectType)
+		{
 			// Mock implementation?
-			if(m_sObjectByMockDomain.containsKey(domainSObjectType))
-				return m_sObjectByMockDomain.get(domainSObjectType);
+			if (mockDomainByObject.containsKey(objectType))
+				return mockDomainByObject.get(objectType);
 
 			// Determine SObjectType and Apex classes for Domain class
-			Type domainConstructorClass = m_sObjectByDomainConstructorType.get(domainSObjectType);
+			Type domainConstructorClass = constructorTypeByObject.get(objectType);
 			if(domainConstructorClass==null)
-				throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
+				throw new DeveloperException('Domain constructor class not found for SObjectType ' + objectType);
 
 			// Construct Domain class passing in the queried records
-			fflib_SObjectDomain.IConstructable domainConstructor = 
-				(fflib_SObjectDomain.IConstructable) domainConstructorClass.newInstance();		
-			return (fflib_ISObjectDomain) domainConstructor.construct(records);
-		}	
+			Object domainConstructor = domainConstructorClass.newInstance();
+
+			// for backwards compatibility
+			if (domainConstructor instanceof fflib_SObjectDomain.IConstructable2)
+			{
+				return (fflib_IDomain)
+						((fflib_SObjectDomain.IConstructable2) domainConstructor)
+								.construct((List<SObject>) objects,	(SObjectType) objectType);
+			}
+			else if (domainConstructor instanceof fflib_SObjectDomain.IConstructable)
+			{
+				return (fflib_IDomain)
+						((fflib_SObjectDomain.IConstructable) domainConstructor)
+								.construct((List<SObject>) objects);
+			}
+
+			return ((fflib_IDomainConstructor) domainConstructor)
+						.construct(objects);
+		}
 
 		/**
 		 * Dynamically constructs an instance of the Domain class for the given records and SObjectType
@@ -347,30 +384,40 @@ public virtual class fflib_Application
 		 * @remark Will support List<SObject> but all records in the list will be assumed to be of
 		 *         the type specified in sObjectType
 		 **/
-		public virtual fflib_ISObjectDomain newInstance(List<SObject> records, SObjectType domainSObjectType)
+		public virtual fflib_IDomain newInstance(List<SObject> records, SObjectType domainSObjectType)
 		{
 			if(domainSObjectType==null)
 				throw new DeveloperException('Must specify sObjectType');
 
-			// Mock implementation?
-			if(m_sObjectByMockDomain.containsKey(domainSObjectType))
-				return m_sObjectByMockDomain.get(domainSObjectType);
-
-			// Determine SObjectType and Apex classes for Domain class
-			Type domainConstructorClass = m_sObjectByDomainConstructorType.get(domainSObjectType);
-			if(domainConstructorClass==null)
-				throw new DeveloperException('Domain constructor class not found for SObjectType ' + domainSObjectType);
-
-			// Construct Domain class passing in the queried records
-			fflib_SObjectDomain.IConstructable2 domainConstructor = 
-				(fflib_SObjectDomain.IConstructable2) domainConstructorClass.newInstance();
-			return (fflib_ISObjectDomain) domainConstructor.construct(records, domainSObjectType);
+			return newInstance(
+					(List<Object>) records,
+					(Object) domainSObjectType
+			);
 		}
 
 		@TestVisible
 		private virtual void setMock(fflib_ISObjectDomain mockDomain)
 		{
-			m_sObjectByMockDomain.put(mockDomain.sObjectType(), mockDomain);			
+			mockDomainByObject.put((Object) mockDomain.sObjectType(), (fflib_IDomain) mockDomain);
+		}
+
+		@TestVisible
+		private virtual void setMock(fflib_IDomain mockDomain)
+		{
+			mockDomainByObject.put(mockDomain.getType(), mockDomain);
+		}
+
+		private Map<Object, Type> getConstructorTypeByObject(Map<SObjectType, Type> constructorTypeBySObjectType)
+		{
+			Map<Object, Type> result = new Map<Object, Type>();
+			for (SObjectType sObjectType : constructorTypeBySObjectType.keySet())
+			{
+				result.put(
+						(Object) sObjectType,
+						constructorTypeBySObjectType.get(sObjectType)
+				);
+			}
+			return result;
 		}
 	}
 

--- a/sfdx-source/apex-common/main/classes/fflib_IDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomain.cls
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public interface fflib_IDomain
+{
+	Object getType();
+	List<Object> getObjects();
+}

--- a/sfdx-source/apex-common/main/classes/fflib_IDomain.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomain.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public interface fflib_IDomainConstructor
+{
+	fflib_IDomain construct(List<Object> objects);
+}

--- a/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_IObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IObjects.cls
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public interface fflib_IObjects extends fflib_IDomain
+{
+	/**
+	 * @param value Values to check if they are part of the domain
+	 *
+	 * @return True if the provided value is part of the domain
+	 */
+	Boolean contains(Object value);
+
+	/**
+	 * @param values Values to check if they are part of the domain
+	 *
+	 * @return True if all the provided values are part of the domain
+	 */
+	Boolean containsAll(List<Object> values);
+
+	/**
+	 * @param values Values to check if they are part of the domain
+	 *
+	 * @return True if all the provided values are part of the domain
+	 */
+	Boolean containsAll(Set<Object> values);
+
+	/**
+	 * @param value Value to check if it is part of the domain
+	 *
+	 * @return True if the provided value is not part of the domain
+	 */
+	Boolean containsNot(Object value);
+
+	/**
+	 * @param values Values to check if they are part of the domain
+	 *
+	 * @return True if all the provided values are not part of the domain
+	 */
+	Boolean containsNot(List<Object> values);
+
+	/**
+	 * @param values Values to check if they are part of the domain
+	 *
+	 * @return True if all the provided values are not part of the domain
+	 */
+	Boolean containsNot(Set<Object> values);
+
+	/**
+	 * @return Returns True is the domain is empty
+	 */
+	Boolean isEmpty();
+
+	/**
+	 * @return Returns True is the domain has objects
+	 */
+	Boolean isNotEmpty();
+}

--- a/sfdx-source/apex-common/main/classes/fflib_IObjects.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_IObjects.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectDomain.cls
@@ -24,7 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 
-public interface fflib_ISObjectDomain 
+public interface fflib_ISObjectDomain extends fflib_IDomain
 {
     /**
      * Returns the SObjectType this Domain class represents

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public interface fflib_ISObjects extends fflib_IObjects
+{
+	/**
+	 * @return Return the SObject records contained in the domain
+	 */
+	List<SObject> getRecords();
+
+	/**
+	 * @return Return the SObject records ids contained in the domain
+	 */
+	Set<Id> getRecordIds();
+
+	/**
+	 * @return Return the SObjectType of the SObjects contained in the domain
+	 */
+	SObjectType getSObjectType();
+}

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_Objects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Objects.cls
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public virtual class fflib_Objects implements fflib_IObjects
+{
+	protected List<Object> objects { get; private set;} { objects = new List<Object>(); }
+
+	/**
+	 * Class constructor
+	 */
+	public fflib_Objects(List<Object> objects)
+	{
+		this.objects = objects.clone();
+	}
+
+	public virtual Object getType()
+	{
+		return Object.class;
+	}
+
+	public List<Object> getObjects()
+	{
+		return this.objects;
+	}
+
+	public Boolean contains(Object value)
+	{
+		return getObjects()?.contains(value);
+	}
+
+	public Boolean containsAll(List<Object> values)
+	{
+		if (values == null) return false;
+
+		return containsAll(new Set<Object>(values));
+	}
+
+	public Boolean containsAll(Set<Object> values)
+	{
+		if (values == null) return false;
+
+		for (Object value : values)
+		{
+			if (!getObjects()?.contains(value)) return false;
+		}
+		return true;
+	}
+
+	public Boolean containsNot(Object value)
+	{
+		return !contains(value);
+	}
+
+	public Boolean containsNot(List<Object> values)
+	{
+		if (values == null) return true;
+
+		return containsNot(new Set<Object>(values));
+	}
+
+	public Boolean containsNot(Set<Object> values)
+	{
+		if (values == null) return true;
+
+		for (Object value : values)
+		{
+			if (getObjects()?.contains(value)) return false;
+		}
+		return true;
+	}
+
+	public Boolean isEmpty()
+	{
+		return (getObjects() == null || getObjects().isEmpty());
+	}
+
+	public Boolean isNotEmpty()
+	{
+		return !isEmpty();
+	}
+
+	protected void setObjects(List<Object> objects)
+	{
+		this.objects = objects;
+	}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_Objects.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_Objects.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
@@ -39,12 +39,18 @@
  *
  **/
 public virtual with sharing class fflib_SObjectDomain
+		extends fflib_SObjects
 	implements fflib_ISObjectDomain
 {
 	/**
 	 * Provides access to the data represented by this domain class
 	 **/
-	public List<SObject> Records { get; private set;}
+	public List<SObject> Records {
+		get
+		{
+			return getRecords();
+		}
+	}
 
 
 	/**
@@ -74,19 +80,14 @@ public virtual with sharing class fflib_SObjectDomain
 	}
 
 	/**
-	 * Derived from the records provided during construction, provides the native describe for the standard or custom object
-	 **/
-	public Schema.DescribeSObjectResult SObjectDescribe {get; private set;}
-
-	/**
 	 * Exposes the configuration for this domain class instance
 	 **/ 
 	public Configuration Configuration {get; private set;}    
 		
 	/**
-	 * Useful during unit testign to assert at a more granular and robust level for errors raised during the various trigger events
-	 **/	
-	public static ErrorFactory Errors  {get; private set;}
+	 * DEPRECATED, This property has been moved to fflib_SObjects
+	 **/
+	public static fflib_SObjectDomain.ErrorFactory Errors {get; private set;}
 	
 	/**
 	 * Useful during unit testing to access mock support for database inserts and updates (testing without DML)
@@ -105,8 +106,8 @@ public virtual with sharing class fflib_SObjectDomain
 
 	static
 	{
-		Errors = new ErrorFactory();
-		
+		Errors = new fflib_SObjectDomain.ErrorFactory();
+
 		Test = new TestFactory();
 		
 		TriggerStateByClass = new Map<Type, List<fflib_SObjectDomain>>();
@@ -137,10 +138,9 @@ public virtual with sharing class fflib_SObjectDomain
 	public fflib_SObjectDomain(List<SObject> sObjectList, SObjectType sObjectType)
 	{
 		// Ensure the domain class has its own copy of the data
-		Records = sObjectList.clone(); 
-		// Capture SObjectType describe for this domain class
-		SObjectDescribe = sObjectType.getDescribe();
-		// Configure the Domain object instance 
+		super(sObjectList, sObjectType);
+
+		// Configure the Domain object instance
 		Configuration = new Configuration();		
 	}
 	
@@ -278,27 +278,11 @@ public virtual with sharing class fflib_SObjectDomain
     /**
      * Returns the SObjectType this Domain class represents
      **/
-    public SObjectType getSObjectType()
-    {
-    	return SObjectDescribe.getSObjectType();
-    }
-
-    /**
-     * Returns the SObjectType this Domain class represents
-     **/
     public SObjectType sObjectType()
     {
     	return getSObjectType();
     }
 
-    /**
-     * Alternative to the Records property, provided to support mocking of Domain classes
-     **/
-    public List<SObject> getRecords()
-    {
-    	return Records;
-    }
-    
 	/**
 	 * Detects whether any values in context records have changed for given fields as strings
 	 * Returns list of SObject records that have changes in the specified fields
@@ -480,7 +464,8 @@ public virtual with sharing class fflib_SObjectDomain
 		if(domains==null || domains.size()==0)
 			return null;		
 		fflib_SObjectDomain domain = domains.remove(domains.size()-1);
-		domain.Records = records;
+
+		domain.setObjects(records);
 		return domain;
 	}
 	
@@ -674,34 +659,34 @@ public virtual with sharing class fflib_SObjectDomain
 	/**
 	 * Ensures logging of errors in the Domain context for later assertions in tests
 	 **/
-	public String error(String message, SObject record)
+	public override String error(String message, SObject record)
 	{
-		return Errors.error(this, message, record);	
+		return fflib_SObjectDomain.Errors.error(this, message, record);
 	}
 	
 	/**
 	 * Ensures logging of errors in the Domain context for later assertions in tests
 	 **/
-	public String error(String message, SObject record, SObjectField field)
+	public override String error(String message, SObject record, SObjectField field)
 	{
-		return Errors.error(this, message, record, field);	
+		return fflib_SObjectDomain.Errors.error(this, message, record, field);
 	}
-	
+
 	/**
-	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 * DEPRECATED, This class has been moved to fflib_SObjects
 	 **/
 	public class ErrorFactory
 	{
-		private List<Error> errorList = new List<Error>(); 
-		
+		private List<Error> errorList = new List<Error>();
+
 		private ErrorFactory()
 		{
-			
+
 		}
-		
+
 		public String error(String message, SObject record)
 		{
-			return error(null, message, record);	
+			return error(null, message, record);
 		}
 
 		private String error(fflib_SObjectDomain domain, String message, SObject record)
@@ -711,12 +696,12 @@ public virtual with sharing class fflib_SObjectDomain
 			objectError.message = message;
 			objectError.record = record;
 			errorList.add(objectError);
-			return message;	
+			return message;
 		}
-		
+
 		public String error(String message, SObject record, SObjectField field)
 		{
-			return error(null, message, record, field);	
+			return error(null, message, record, field);
 		}
 
 		private String error(fflib_SObjectDomain domain, String message, SObject record, SObjectField field)
@@ -727,48 +712,48 @@ public virtual with sharing class fflib_SObjectDomain
 			fieldError.record = record;
 			fieldError.field = field;
 			errorList.add(fieldError);
-			return message;	
-		}	
-			
+			return message;
+		}
+
 		public List<Error> getAll()
-		{ 
+		{
 			return errorList.clone();
 		}
-		
+
 		public void clearAll()
 		{
 			errorList.clear();
-		}					
+		}
 	}
 	
 	/**
-	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 * DEPRECATED, This class has been moved to fflib_SObjects
 	 **/
 	public virtual class FieldError extends ObjectError
 	{
 		public SObjectField field;
-		
+
 		public FieldError()
-		{		
-			
+		{
+
 		}
 	}
-	
+
 	/**
-	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 * DEPRECATED, This class has been moved to fflib_SObjects
 	 **/
 	public virtual class ObjectError extends Error
 	{
 		public SObject record;
-		
+
 		public ObjectError()
 		{
-		
+
 		}
 	}
-	
+
 	/**
-	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 * DEPRECATED, This class has been moved to fflib_SObjects
 	 **/
 	public abstract class Error
 	{

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -1,0 +1,368 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public virtual class fflib_SObjects
+		extends fflib_Objects
+		implements fflib_ISObjects
+{
+
+	public Schema.DescribeSObjectResult SObjectDescribe {get; private set;}
+
+	/**
+	 * Useful during unit testing to assert at a more granular and robust level for errors raised during the various trigger events
+	 **/
+	public static ErrorFactory Errors  {get; private set;}
+
+	static
+	{
+		Errors = new ErrorFactory();
+	}
+
+	/**
+	 * Class constructor
+	 */
+	public fflib_SObjects(List<SObject> records)
+	{
+		super(records);
+	}
+
+	public fflib_SObjects(List<SObject> records, Schema.SObjectType sObjectType)
+	{
+		super(records);
+		SObjectDescribe = sObjectType.getDescribe();
+	}
+
+	public virtual List<SObject> getRecords()
+	{
+		return (List<SObject>) getObjects();
+	}
+
+	public virtual Set<Id> getRecordIds()
+	{
+		return new Map<Id, SObject>(getRecords()).keySet();
+	}
+
+	public virtual override Object getType()
+	{
+		return getSObjectType();
+	}
+
+	public virtual SObjectType getSObjectType()
+	{
+		return SObjectDescribe.getSObjectType();
+	}
+
+	/**
+	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 *
+	 * @param message
+	 * @param record
+	 *
+	 * @return Returns the Error message
+	 **/
+	protected virtual String error(String message, SObject record)
+	{
+		return Errors.error(this, message, record);
+	}
+
+	/**
+	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 *
+	 * @param message
+	 * @param record
+	 * @param field
+	 *
+	 * @return Returns the Error message
+	 **/
+	protected virtual String error(String message, SObject record, SObjectField field)
+	{
+		return fflib_SObjects.Errors.error(this, message, record, field);
+	}
+
+	protected virtual Set<Object> getFieldValues(Schema.SObjectField sObjectField)
+	{
+		Set<Object> result = new Set<Object>();
+		for (SObject record : getRecords())
+		{
+			result.add(record.get(sObjectField));
+		}
+		return result;
+	}
+
+	/**
+	 * @param sObjectField The Schema.SObjectField to compare against the given value
+	 * @param value The given value of the records sObjectField to include in the return
+	 *
+	 * @return A list with only the SObjects where the given sObjectField has the provided value
+	 */
+	protected virtual List<SObject> getRecordsByFieldValue(Schema.SObjectField sObjectField, Object value)
+	{
+		return getRecordsByFieldValues(sObjectField, new Set<Object>{value});
+	}
+
+	/**
+	 * @param sObjectField The Schema.SObjectField to compare against the given value
+	 * @param values The given values of the records sObjectField to include in the return
+	 *
+	 * @return A list with only the SObjects where the given sObjectField value is part of the provided values
+	 */
+	protected virtual List<SObject> getRecordsByFieldValues(Schema.SObjectField sObjectField, Set<Object> values)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			if (values?.contains(record.get(sObjectField)))
+			{
+				result.add(record);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * @param sObjectField The Schema.SObjectField to check its value for a Blank value
+	 *
+	 * @return A list with only the SObjects where the given sObjectField value is either null or '')
+	 */
+	protected virtual List<SObject> getRecordsWithBlankFieldValues(Schema.SObjectField sObjectField)
+	{
+		return getRecordsWithBlankFieldValues(
+				new Set<Schema.SObjectField> {sObjectField}
+		);
+	}
+
+	/**
+	 * @param sObjectFields The Schema.SObjectField's to check their value for a Blank value
+	 *
+	 * @return A list with only the SObjects where the at least one given sObjectField value is either null or '')
+	 */
+	protected virtual List<SObject> getRecordsWithBlankFieldValues(Set<Schema.SObjectField> sObjectFields)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			for (SObjectField sObjectField : sObjectFields)
+			{
+				if (String.isBlank((String) record.get(sObjectField)))
+				{
+					result.add(record);
+					break;
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * @param sObjectFields The Schema.SObjectField's to check their value for a Blank value
+	 *
+	 * @return A list with only the SObjects where the at least one given sObjectField value is either null or ''
+	 */
+	protected virtual List<SObject> getRecordsWithAllBlankFieldValues(Set<Schema.SObjectField> sObjectFields)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			Boolean allBlank = true;
+			for (SObjectField sObjectField : sObjectFields)
+			{
+				if (String.isNotBlank((String) record.get(sObjectField)))
+				{
+					allBlank = false;
+					break;
+				}
+			}
+			if (allBlank) result.add(record);
+		}
+		return result;
+	}
+
+	/**
+	 * @param sObjectField The Schema.SObjectField to check its value for a Non-Blank value
+	 *
+	 * @return A list with only the SObjects where the given sObjectField value is not null or ''
+	 */
+	protected virtual List<SObject> getRecordsWithNotBlankFieldValues(Schema.SObjectField sObjectField)
+	{
+		return getRecordsWithNotBlankFieldValues(
+				new Set<Schema.SObjectField> {sObjectField}
+		);
+	}
+
+	/**
+	 * @param sObjectFields The Schema.SObjectField's to check their value for a Non-Blank value
+	 *
+	 * @return A list with only the SObjects where the at least one given sObjectField value not null or ''
+	 */
+	protected virtual List<SObject> getRecordsWithNotBlankFieldValues(Set<Schema.SObjectField> sObjectFields)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			for (SObjectField sObjectField : sObjectFields)
+			{
+				if (String.isBlank((String) record.get(sObjectField)))
+				{
+					result.add(record);
+					break;
+				}
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * @param sObjectFields The Schema.SObjectField's to check their value for a Non-Blank value
+	 *
+	 * @return A list with only the SObjects where the at least one given sObjectField value is not null or ''
+	 */
+	protected virtual List<SObject> getRecordsWithAllNotBlankFieldValues(Set<Schema.SObjectField> sObjectFields)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			Boolean allNonBlank = true;
+			for (SObjectField sObjectField : sObjectFields)
+			{
+				if (String.isBlank((String) record.get(sObjectField)))
+				{
+					allNonBlank = false;
+					break;
+				}
+			}
+			if (allNonBlank) result.add(record);
+		}
+		return result;
+	}
+
+
+	protected virtual void setFieldValue(Schema.SObjectField sObjectField, Object value)
+	{
+		for (SObject record : getRecords())
+		{
+			record.put(sObjectField, value);
+		}
+	}
+
+	/**
+	 * @param sObjectFieldToCheck The SObjectField to match the key against in the provided map
+	 * @param sObjectFieldToUpdate The SObjectField to store the mapped value when the key matches the value in the sObjectFieldToUpdate field
+	 * @param values Map of values to store by the sObjectFieldToCheck fields value
+	 */
+	protected virtual void setFieldValueByMap(
+			Schema.SObjectField sObjectFieldToCheck,
+			Schema.SObjectField sObjectFieldToUpdate,
+			Map<Object, Object> values)
+	{
+		for (SObject record : getRecords())
+		{
+			Object keyValue = record.get(sObjectFieldToCheck);
+			if (values?.containsKey(keyValue))
+			{
+				record.put(sObjectFieldToUpdate, values.get(keyValue));
+			}
+		}
+	}
+
+	/**
+     * Ensures logging of errors in the Domain context for later assertions in tests
+     **/
+	public virtual class ErrorFactory
+	{
+		private List<Error> errorList = new List<Error>();
+
+		private ErrorFactory() {	}
+
+		public String error(String message, SObject record)
+		{
+			return error(null, message, record);
+		}
+
+		public String error(fflib_SObjects domain, String message, SObject record)
+		{
+			ObjectError objectError = new ObjectError();
+			objectError.domain = domain;
+			objectError.message = message;
+			objectError.record = record;
+			errorList.add(objectError);
+			return message;
+		}
+
+		public String error(String message, SObject record, SObjectField field)
+		{
+			return error(null, message, record, field);
+		}
+
+		public String error(fflib_ISObjects domain, String message, SObject record, SObjectField field)
+		{
+			FieldError fieldError = new FieldError();
+			fieldError.domain = domain;
+			fieldError.message = message;
+			fieldError.record = record;
+			fieldError.field = field;
+			errorList.add(fieldError);
+			return message;
+		}
+
+		public List<Error> getAll()
+		{
+			return errorList.clone();
+		}
+
+		public void clearAll()
+		{
+			errorList.clear();
+		}
+	}
+
+	/**
+	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 **/
+	public virtual class FieldError extends ObjectError
+	{
+		public SObjectField field;
+
+		public FieldError()	{ }
+	}
+
+	/**
+	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 **/
+	public virtual class ObjectError extends Error
+	{
+		public SObject record;
+
+		public ObjectError() { }
+	}
+
+	/**
+	 * Ensures logging of errors in the Domain context for later assertions in tests
+	 **/
+	public abstract class Error
+	{
+		public String message;
+		public fflib_ISObjects domain;
+	}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
@@ -32,14 +32,14 @@ private class fflib_ApplicationTest
 	{
 		// Registered Accounts domain class by SObject List
 		Id testAccountId = fflib_IDGenerator.generate(Account.SObjectType);
-		fflib_ISObjectDomain domainObjectAcct = 
+		fflib_IDomain domainObjectAcct =
 			Domain.newInstance(
 				new List<Account> 
 					{ new Account( 
 						Id = testAccountId,
 						Name = 'Test Account') });
 		System.assert(domainObjectAcct instanceof AccountsDomain);
-		System.assertEquals(testAccountId, domainObjectAcct.getRecords()[0].Id);
+		System.assertEquals(testAccountId, getFirstSObject(domainObjectAcct).Id);
 
 		// Registered Accounts domain class by SObject List
 		testAccountId = fflib_IDGenerator.generate(Account.SObjectType);
@@ -51,17 +51,17 @@ private class fflib_ApplicationTest
 						Name = 'Test Account') }
 				, Account.SObjectType);
 		System.assert(domainObjectAcct instanceof AccountsDomain);
-		System.assertEquals(testAccountId, domainObjectAcct.getRecords()[0].Id);		
+		System.assertEquals(testAccountId, getFirstSObject(domainObjectAcct).Id);
 
 		// Registered Opportunities domain class by SObject List
 		Id testOpportunityId = fflib_IDGenerator.generate(Opportunity.SObjectType);
-		fflib_ISObjectDomain domainObjectOpp = 
+		fflib_IDomain domainObjectOpp =
 			Domain.newInstance(
 				new List<Opportunity> 
 					{ new Opportunity( 
 						Id = testOpportunityId,
 						Name = 'Test Opportunity') });
-		System.assertEquals(testOpportunityId, domainObjectOpp.getRecords()[0].Id);		
+		System.assertEquals(testOpportunityId, getFirstSObject(domainObjectOpp).Id);
 		System.assert(domainObjectOpp instanceof OpportuntiesDomain);
 
 		// Test failure for creating new instance using IConstructable2
@@ -74,7 +74,7 @@ private class fflib_ApplicationTest
 						Id = testOpportunityId,
 						Name = 'Test Opportunity') }
 				, Opportunity.SObjectType);
-		System.assertEquals(testOpportunityId, domainObjectOpp.getRecords()[0].Id);		
+		System.assertEquals(testOpportunityId, getFirstSObject(domainObjectOpp).Id);
 		System.assert(domainObjectOpp instanceof OpportuntiesDomain);
 
 		// Given
@@ -109,6 +109,11 @@ private class fflib_ApplicationTest
 		System.assert(domainObjectAcct instanceof fflib_SObjectMocks.SObjectDomain);		
 	}
 
+	private static SObject getFirstSObject(fflib_IDomain domainObjectAcct)
+	{
+		return ((List<SObject>) domainObjectAcct.getObjects())[0];
+	}
+
 	@IsTest
 	private static void callingDomainFactoryWithIdsShouldGiveRegisteredImpls()
 	{
@@ -129,12 +134,12 @@ private class fflib_ApplicationTest
 
 		// When
 		Selector.setMock(selectorMock);
-		fflib_ISObjectDomain domainObjectAcc = Domain.newInstance(new Set<Id> { testAccountId });
+		fflib_IDomain domainObjectAcc = Domain.newInstance(new Set<Id> { testAccountId });
 
 		// Then
-		List<Account> assertAccounts = (List<Account>) domainObjectAcc.getRecords();
+		List<Account> assertAccounts = (List<Account>) domainObjectAcc.getObjects();
 		System.assert(domainObjectAcc instanceof AccountsDomain);
-		System.assertEquals(testAccountId, domainObjectAcc.getRecords()[0].Id);		
+		System.assertEquals(testAccountId, getFirstSObject(domainObjectAcc).Id);
 		System.assertEquals(1, assertAccounts.size());
 		System.assertEquals(testAccountId, assertAccounts[0].Id);
 		System.assertEquals('Test Account', assertAccounts[0].Name);
@@ -187,7 +192,8 @@ private class fflib_ApplicationTest
 			Domain.newInstance(new List<Contact>{ new Contact(LastName = 'TestContactLName') });
 			System.assert(false, 'Expected exception');
 		} catch (System.TypeException e) {
-			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_SObjectDomain\\.IConstructable',
+
+			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_IDomainConstructor',
 				e.getMessage()), 'Exception message did not match the expected pattern: ' + e.getMessage());
 		}	
 
@@ -195,7 +201,7 @@ private class fflib_ApplicationTest
 			Domain.newInstance(new List<SObject>{ new Contact(LastName = 'TestContactLName') }, Contact.SObjectType);
 			System.assert(false, 'Expected exception');
 		} catch (System.TypeException e) {
-			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_SObjectDomain\\.IConstructable2',
+			System.assert(Pattern.Matches('Invalid conversion from runtime type \\w*\\.?fflib_ApplicationTest\\.ContactsConstructor to \\w*\\.?fflib_IDomainConstructor',
 				e.getMessage()), 'Exception message did not match the expected pattern: ' + e.getMessage());
 		}		
 	}	

--- a/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+
+@IsTest
+private class fflib_ObjectsTest
+{
+	private static final fflib_ObjectsTest.DataTransferObject TRANSFER_OBJECT_A = new DataTransferObject('Test A');
+	private static final fflib_ObjectsTest.DataTransferObject TRANSFER_OBJECT_B = new DataTransferObject('Test B');
+	private static final fflib_ObjectsTest.DataTransferObject TRANSFER_OBJECT_C = new DataTransferObject('Test C');
+	private static final fflib_ObjectsTest.DataTransferObject TRANSFER_OBJECT_D = new DataTransferObject('Test D');
+
+	@IsTest
+	static void itShouldReturnTheCorrectType()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = new Domain(
+				new List<DataTransferObject>
+				{
+						TRANSFER_OBJECT_A,
+						TRANSFER_OBJECT_B
+				}
+		);
+
+		System.assertEquals(
+				DataTransferObject.class,
+				dtoDomain.getType(),
+				'Wrong domain type'
+		);
+	}
+
+	@IsTest
+	static void itShouldContainTheObject()
+	{
+		fflib_ObjectsTest.DataTransferObject transferObject = TRANSFER_OBJECT_A;
+		fflib_ObjectsTest.Domain dtoDomain = new Domain(
+				new List<DataTransferObject>
+				{
+						transferObject,
+						TRANSFER_OBJECT_B
+				}
+		);
+
+		System.assert(
+				dtoDomain.contains(transferObject),
+				'The object should have been part of the domain'
+		);
+	}
+
+	@IsTest
+	static void itShouldNotContainTheObject()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = generateDomain();
+
+		System.assert(
+				dtoDomain.containsNot(TRANSFER_OBJECT_D),
+				'The object should not have been part of the domain'
+		);
+	}
+
+	@IsTest
+	static void itShouldNotContainTheObjects()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = new Domain(
+				new List<Object>
+				{
+						TRANSFER_OBJECT_A,
+						TRANSFER_OBJECT_B
+				});
+
+		System.assert(
+				dtoDomain.containsNot(
+						new Set<Object>
+						{
+								TRANSFER_OBJECT_C,
+								TRANSFER_OBJECT_D
+						}),
+				'The set of objects should not have been part of the domain'
+		);
+		System.assert(
+				dtoDomain.containsNot(
+						new List<Object>
+						{
+								TRANSFER_OBJECT_C,
+								TRANSFER_OBJECT_D
+						}),
+				'The list of objects should not have been part of the domain'
+		);
+	}
+
+	@IsTest
+	static void itShouldHaveAnEmptyDomain()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = new Domain(new List<DataTransferObject>());
+		System.assert(dtoDomain.isEmpty(), 'Domain should be empty');
+	}
+
+	@IsTest
+	static void itShouldNotBeAnEmptyDomain()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = generateDomain();
+		System.assert(dtoDomain.isNotEmpty(), 'Domain should not be empty');
+	}
+
+
+	@IsTest
+	static void itShouldContainAllTheObjects()
+	{
+		fflib_ObjectsTest.Domain dtoDomain = generateDomain();
+
+		System.assert(
+				dtoDomain.containsAll(
+						new List<DataTransferObject>
+						{
+								TRANSFER_OBJECT_A,
+								TRANSFER_OBJECT_B
+						}
+				),
+				'Domain should contain the whole List of objects'
+		);
+		System.assert(
+				dtoDomain.containsAll(
+						new Set<Object>
+						{
+								TRANSFER_OBJECT_A,
+								TRANSFER_OBJECT_B
+						}
+				),
+				'Domain should contain the whole Set of objects'
+		);
+	}
+
+	private static Domain generateDomain()
+	{
+		return new Domain(generateDataTransferObjects());
+	}
+
+
+	private static List<DataTransferObject> generateDataTransferObjects()
+	{
+		return new List<DataTransferObject>
+		{
+				TRANSFER_OBJECT_A,
+				TRANSFER_OBJECT_B,
+				TRANSFER_OBJECT_C
+		};
+	}
+
+
+	private class Domain extends fflib_Objects
+	{
+		public Domain(List<Object> objects)
+		{
+			super(objects);
+		}
+
+		public override Object getType()
+		{
+			return DataTransferObject.class;
+		}
+	}
+
+	private class DataTransferObject
+	{
+		public String MyProperty { get; set; }
+
+		public DataTransferObject(String property)
+		{
+			this.MyProperty = property;
+		}
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+
+@IsTest
+private class fflib_SObjectsTest
+{
+
+	@IsTest
+	static void itShouldReturnTheDomainsType()
+	{
+		System.assertEquals(
+				(Object) Schema.Account.SObjectType,
+				new DomainAccounts(new List<Account>())
+						.getType(),
+				'Unexpected Domain Type'
+		);
+		System.assertEquals(
+				Schema.Account.SObjectType,
+				new DomainAccounts(new List<Account>())
+						.getSObjectType(),
+				'Unexpected Domain SObjectType'
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnRecordsWithFieldValues()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectByShippingCountry('USA').size() == 1);
+	}
+
+	@IsTest
+	static void itShouldReturnRecordsWithoutFieldValues()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectWithoutShippingCountry().size() == 3);
+	}
+
+	@IsTest
+	static void itShouldReturnRecordsWithoutAllFieldValues()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectWithEmptyRecord().size() == 1);
+	}
+
+	@IsTest
+	static void itShouldReturnRecordsWithShippingCountry()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectWithShippingCountry().size() == 3);
+	}
+
+	@IsTest
+	static void itShouldReturnRecordsWithAllFieldValues()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectPopulatedRecords().size() == 3);
+	}
+
+	@IsTest
+	static void itShouldSetFieldValue()
+	{
+		DomainAccounts domain = generateDomain();
+		String country = 'Holland';
+		domain.setShippingCountry(country);
+
+		System.assert(domain.selectByShippingCountry(country).size() == 6);
+	}
+
+
+	@IsTest
+	static void itShouldSetFieldValueByCondition()
+	{
+		DomainAccounts domain = generateDomain();
+		domain.setRatingByShippingCountry(
+				new Map<Object,Object>
+				{
+						'USA' => 'Hot'
+				}
+		);
+
+		System.assert(domain.selectByRating('Hot').size() == 1);
+	}
+
+	@IsTest
+	static void testErrorLogging()
+	{
+		// Test static helpers for raise none domain object instance errors
+		Opportunity opp = new Opportunity ( Name = 'Test', Type = 'Existing Account' );
+		fflib_SObjects.Errors.error('Error', opp);
+		fflib_SObjects.Errors.error('Error', opp, Opportunity.Type);
+		System.assertEquals(2, fflib_SObjects.Errors.getAll().size());
+		System.assertEquals('Error', fflib_SObjects.Errors.getAll()[0].message);
+		System.assertEquals('Error', fflib_SObjects.Errors.getAll()[1].message);
+		System.assertEquals(Opportunity.Type, ((fflib_SObjects.FieldError) fflib_SObjects.Errors.getAll()[1]).field);
+		fflib_SObjects.Errors.clearAll();
+		System.assertEquals(0, fflib_SObjects.Errors.getAll().size());
+	}
+
+	private static DomainAccounts generateDomain()
+	{
+		DomainAccounts domain = new DomainAccounts(
+				new List<Account>
+				{
+						new Account(Name = 'A', ShippingCountry = 'USA'),
+						new Account(Name = 'B', ShippingCountry = 'Ireland'),
+						new Account(Name = 'C', ShippingCountry = 'UK'),
+						new Account(Name = 'D', ShippingCountry = ''),
+						new Account(Name = 'E'),
+						new Account()
+				}
+		);
+		return domain;
+	}
+
+
+	private class DomainAccounts extends fflib_SObjects
+	{
+		public DomainAccounts(List<SObject> records)
+		{
+			super(records, Schema.Account.SObjectType);
+		}
+
+		public List<Account> selectByShippingCountry(String country)
+		{
+			return (List<Account>) getRecordsByFieldValues(
+				Schema.Account.ShippingCountry,
+				new Set<Object>{ country }
+			);
+		}
+
+		public List<Account> selectByRating(String rating)
+		{
+			return (List<Account>) getRecordsByFieldValue(
+				Schema.Account.Rating,
+					rating
+			);
+		}
+
+		public List<Account> selectWithoutShippingCountry()
+		{
+			return (List<Account>) getRecordsWithBlankFieldValues(
+							Schema.Account.ShippingCountry
+			);
+		}
+
+		public List<Account> selectWithShippingCountry()
+		{
+			return (List<Account>) getRecordsWithNotBlankFieldValues(
+							Schema.Account.ShippingCountry
+			);
+		}
+
+		public List<Account> selectWithEmptyRecord()
+		{
+			return (List<Account>) getRecordsWithAllBlankFieldValues(
+					new Set<Schema.SObjectField>
+					{
+							Schema.Account.Name,
+							Schema.Account.ShippingCountry
+					}
+			);
+		}
+
+		public List<Account> selectPopulatedRecords()
+		{
+			return (List<Account>) getRecordsWithAllNotBlankFieldValues(
+					new Set<Schema.SObjectField>
+					{
+							Schema.Account.Name,
+							Schema.Account.ShippingCountry
+					}
+			);
+		}
+
+		public void setShippingCountry(String country)
+		{
+			setFieldValue(Schema.Account.ShippingCountry, country);
+		}
+
+		public void setRatingByShippingCountry(Map<Object, Object> ratingByCountry)
+		{
+			setFieldValueByMap(
+					Schema.Account.ShippingCountry,
+					Schema.Account.Rating,
+					ratingByCountry);
+		}
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
+++ b/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
@@ -46,6 +46,16 @@ public class fflib_SObjectMocks
 		{
 			return (List<SObject>) mocks.mockNonVoidMethod(this, 'getRecords', new List<Type> {}, new List<Object> {});
 		}
+
+		public Object getType()
+		{
+			return sObjectType();
+		}
+
+		public List<Object> getObjects()
+		{
+			return getRecords();
+		}
 	}
 
 	public virtual class SObjectSelector implements fflib_ISObjectSelector


### PR DESCRIPTION
Domain structure based on Objects instead of SObject to allow for DTO, compound domains and other fun stuff.

@daveespo @ImJohnMDaniel @stohn777 After our discussion I gave it some more thought. And maybe we should flip it around. That we keep the current combined domain plus triggerHandler more-or-less as-is, but that we add a new domain structure above fflib_SObjectDomain and extended it from the new domain.

In this manner you have (almost) 100% backwards compatibility, except for the popTriggerInstance method. I am open to any thoughts on how to best solve that.

Eventually you can deprecate the entire fflib_SObjectDomain class when we have this new Domain structure combined with the future rebuild of the triggerHandler. 
I thought that something like this would keep the source much cleaner without having to redirect everything from old to new and add tons of deprecated messages.

Something that still need to be done in this PR is to modify the fflib_Application to accept fflib_Domain instead of fflib_SObjectDomain, but wanted to share this first to continue the discussion.


The new Interface / implementation structure would then look like this:
- fflib_Domain       (Main interface to define a domain)
- fflib_Objects       (Top level Domain class implementation with generic Objects)
- fflib_SObjects     
Similar to the current fflib_SObjectDomain with standard methods typical for domains. No trigger handler here.
New domain implementation for standard or custom objects should then be extended from this instead of fflib_SObjectDomain e.g. `public with sharing class AccountsImp extends fflib_SObjects implements Accounts`
- fflib_SObjectDomain        for backwards compatibility

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/300)
<!-- Reviewable:end -->
