### PR TITLE
Add support for domain in UnitOfWork

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
@@ -42,6 +42,12 @@ public interface fflib_ISObjectUnitOfWork
      **/
     void registerNew(List<SObject> records);
     /**
+     * Register a list of newly created SObject instances contained in a domain to be inserted when commitWork is called
+     *
+     * @param domain A domain containing newly created SObject instances to be inserted during commitWork
+     **/
+    void registerNew(fflib_ISObjects domain);
+    /**
      * Register a newly created SObject instance to be inserted when commitWork is called,
      *   you may also provide a reference to the parent record instance (should also be registered as new separately)
      *
@@ -99,6 +105,16 @@ public interface fflib_ISObjectUnitOfWork
      **/
     void registerDirty(List<SObject> records, List<SObjectField> dirtyFields);
     /**
+     * Register specific fields on records to be updated when work is committed
+     *
+     * If the records are previously registered as dirty, the dirty fields on the records in this call will overwrite
+     * the values of the previously registered dirty records
+     *
+     * @param Domain A domain containing a list of existing records
+     * @param dirtyFields The fields to update if record is already registered
+     **/
+    void registerDirty(fflib_ISObjects domain, List<SObjectField> dirtyFields);
+    /**
      * Register specific fields on record to be updated when work is committed
      *
      * If the record has previously been registered as dirty, the dirty fields on the record in this call will overwrite
@@ -123,6 +139,12 @@ public interface fflib_ISObjectUnitOfWork
      * @param records A list of existing records
      **/
     void registerDirty(List<SObject> records);
+    /**
+     * Register a list of existing records contained in a domain to be updated during the commitWork method
+     *
+     * @param domain A list of existing records
+     **/
+    void registerDirty(fflib_ISObjects domain);
     /**
 	 * Register an deleted record to be removed from the recycle bin during the commitWork method
 	 *
@@ -160,11 +182,23 @@ public interface fflib_ISObjectUnitOfWork
      **/
     void registerDeleted(List<SObject> records);
     /**
+     * Register a domain containing a list of existing records to be deleted during the commitWork method
+     *
+     * @param domain A domain with existing records
+     **/
+    void registerDeleted(fflib_ISObjects domain);
+    /**
      * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
      *
      * @param records A list of existing records
      **/
     void registerPermanentlyDeleted(List<SObject> records);
+    /**
+     * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
+     *
+     * @param domain A domain with existing records
+     **/
+    void registerPermanentlyDeleted(fflib_ISObjects domain);
     /**
      * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
      *

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -259,6 +259,16 @@ public virtual class fflib_SObjectUnitOfWork
     }
 
     /**
+     * Register a list of newly created SObject instances contained in a domain to be inserted when commitWork is called
+     *
+     * @param domain A domain containing a list of newly created SObject instances to be inserted during commitWork
+     **/
+    public void registerNew(fflib_ISObjects domain)
+    {
+        registerNew(domain.getRecords());
+    }
+
+    /**
      * Register a newly created SObject instance to be inserted when commitWork is called,
      *   you may also provide a reference to the parent record instance (should also be registered as new separately)
      *
@@ -357,6 +367,17 @@ public virtual class fflib_SObjectUnitOfWork
 	    }
     }
 
+    /**
+     * Registers the entire records as dirty or just only the dirty fields if the record was already registered
+     *
+     * @param domain SObjects to register as dirty
+     * @param dirtyFields A list of modified fields
+     */
+    public void registerDirty(fflib_ISObjects domain, List<SObjectField> dirtyFields)
+    {
+        registerDirty(domain.getRecords(), dirtyFields);
+    }
+
 	/**
 	 * Registers the entire record as dirty or just only the dirty fields if the record was already registered
 	 *
@@ -427,6 +448,16 @@ public virtual class fflib_SObjectUnitOfWork
     }
 
     /**
+     * Register a list of existing records to be updated during the commitWork method
+     *
+     * @param domain A list of existing records
+     **/
+    public void registerDirty(fflib_ISObjects domain)
+    {
+        registerDirty(domain.getRecords());
+    }
+
+    /**
      * Register a new or existing record to be inserted/updated during the commitWork method
      *
      * @param record A new or existing record
@@ -486,6 +517,16 @@ public virtual class fflib_SObjectUnitOfWork
         }
     }
 
+    /**
+     * Register a domain containing a list of existing records to be deleted during the commitWork method
+     *
+     * @param domain A domain with existing records
+     **/
+    public void registerDeleted(fflib_ISObjects domain)
+    {
+        registerDeleted(domain.getRecords());
+    }
+
 	/**
      * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
      *
@@ -495,6 +536,16 @@ public virtual class fflib_SObjectUnitOfWork
     {
 	    this.registerEmptyRecycleBin(records);
 	    this.registerDeleted(records);
+    }
+
+    /**
+     * Register a list of existing records to be deleted and removed from the recycle bin during the commitWork method
+     *
+     * @param domain A domain with existing records
+     **/
+    public void registerPermanentlyDeleted(fflib_ISObjects domain)
+    {
+        registerPermanentlyDeleted(domain.getRecords());
     }
 
 	/**

--- a/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
+++ b/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
@@ -97,6 +97,11 @@ public class fflib_SObjectMocks
 			mocks.mockVoidMethod(this, 'registerNew', new List<Type> {List<SObject>.class}, new List<Object> {records});
 		}
 
+		public void registerNew(fflib_ISObjects domain)
+		{
+			mocks.mockVoidMethod(this, 'registerNew', new List<Type> {List<SObject>.class}, new List<Object> {domain});
+		}
+
 		public void registerNew(SObject record, Schema.sObjectField relatedToParentField, SObject relatedToParentRecord)
 		{
 			mocks.mockVoidMethod(this, 'registerNew', new List<Type> {SObject.class, Schema.sObjectField.class, SObject.class}, new List<Object> {record, relatedToParentField, relatedToParentRecord});
@@ -131,6 +136,15 @@ public class fflib_SObjectMocks
 			});
 		}
 
+		public void registerDirty(fflib_ISObjects domain, List<SObjectField> dirtyFields)
+		{
+			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {
+					SObject.class, System.Type.forName('List<SObjectField>')
+			}, new List<Object> {
+					domain, dirtyFields
+			});
+		}
+
 		public void registerDirty(SObject record, List<SObjectField> dirtyFields)
 		{
 			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {
@@ -148,6 +162,11 @@ public class fflib_SObjectMocks
 		public void registerDirty(List<SObject> records)
 		{
 			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {List<SObject>.class}, new List<Object> {records});
+		}
+
+		public void registerDirty(fflib_ISObjects domain)
+		{
+			mocks.mockVoidMethod(this, 'registerDirty', new List<Type> {List<SObject>.class}, new List<Object> {domain});
 		}
 
 		public void registerUpsert(SObject record)
@@ -180,6 +199,11 @@ public class fflib_SObjectMocks
 			mocks.mockVoidMethod(this, 'registerDeleted', new List<Type> {List<SObject>.class}, new List<Object> {records});
 		}
 
+		public void registerDeleted(fflib_ISObjects domain)
+		{
+			mocks.mockVoidMethod(this, 'registerDeleted', new List<Type> {List<SObject>.class}, new List<Object> {domain});
+		}
+
 		public void registerPermanentlyDeleted(SObject record)
 		{
 			mocks.mockVoidMethod(this, 'registerPermanentlyDeleted', new List<Type> {SObject.class}, new List<Object> {record});
@@ -188,6 +212,11 @@ public class fflib_SObjectMocks
 		public void registerPermanentlyDeleted(List<SObject> records)
 		{
 			mocks.mockVoidMethod(this, 'registerPermanentlyDeleted', new List<Type> {SObject.class}, new List<Object> {records});
+		}
+
+		public void registerPermanentlyDeleted(fflib_ISObjects domain)
+		{
+			mocks.mockVoidMethod(this, 'registerPermanentlyDeleted', new List<Type> {SObject.class}, new List<Object> {domain});
 		}
 
 		public void registerPublishBeforeTransaction(SObject record)


### PR DESCRIPTION
With this change you can directly pass a domain class to the unitOfWork to process the records of the domain instead of first have to extract the records and then pass them to the domain\

`unitOfWork.registerNew(accounts.getRecords());` then becomes `unitOfWork.registerNew(accounts);`.

Small change but will make things easier to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/310)
<!-- Reviewable:end -->
