### PR TITLE
A common criteria based filter for Domains and Selectors

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Comparator.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Comparator.cls
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public with sharing class fflib_Comparator
+{
+	public static Boolean compareTo(Object object1, fflib_Operator operator, Object object2)
+	{
+		Integer result = compare(object1, object2);
+
+		if (operator == fflib_Operator.EQUALS && result == 0)
+			return true;
+		else if (operator == fflib_Operator.NOT_EQUALS && result != 0)
+			return true;
+		else if (operator == fflib_Operator.LESS_THAN && result == -1)
+			return true;
+		else if (operator == fflib_Operator.LESS_THAN_OR_EQUAL_TO && result != 1)
+			return true;
+		else if (operator == fflib_Operator.GREATER_THAN && result == 1)
+			return true;
+		else if (operator == fflib_Operator.GREATER_THAN_OR_EQUAL_TO && result != -1)
+			return true;
+		else
+				return false;
+	}
+
+	public static Integer compare(Object object1, Object object2)
+	{
+		if (object1 == null && object2 == null)
+			return 0;
+		else if (object1 == null)
+			return -1;
+		else if (object2 == null)
+			return 1;
+		else if (object1 instanceof Boolean && object2 instanceof Boolean)
+			return compare((Boolean) object1, (Boolean) object2);
+		else if (object1 instanceof Date && object2 instanceof Date)
+			return compare((Date) object1, (Date) object2);
+		else if (object1 instanceof Datetime && object2 instanceof Datetime)
+			return compare((Datetime) object1, (Datetime) object2);
+		else if (object1 instanceof Integer && object2 instanceof Integer)
+			return compare((Integer) object1, (Integer) object2);
+		else if (object1 instanceof Long && object2 instanceof Long)
+			return compare((Long) object1, (Long) object2);
+		else if (object1 instanceof Double && object2 instanceof Double)
+			return compare((Double) object1, (Double) object2);
+		else if (object1 instanceof Time && object2 instanceof Time)
+			return compare((Time) object1, (Time) object2);
+		else if (object1 instanceof String && object2 instanceof String)
+			return compare((String) object1, (String) object2);
+		else
+				throw new IllegalArgumentException(
+						'Both arguments must be type Boolean, Date, Datetime, Decimal, Double, ID, Integer, Long, Time, or String');
+	}
+
+	public static Integer compare(Boolean b1, Boolean b2)
+	{
+		if (!b1 && b2) return -1;
+		else if (b1 == b2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Date d1, Date d2)
+	{
+		if (d1 < d2) return -1;
+		else if (d1 == d2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Datetime d1, Datetime d2)
+	{
+		if (d1 < d2) return -1;
+		else if (d1 == d2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Double d1, Double d2)
+	{
+		if (d1 < d2) return -1;
+		else if (d1 == d2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Integer i1, Integer i2)
+	{
+		if (i1 < i2) return -1;
+		else if (i1 == i2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Long l1, Long l2)
+	{
+		if (l1 < l2) return -1;
+		else if (l1 == l2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(String s1, String s2)
+	{
+		if (s1 < s2) return -1;
+		else if (s1 == s2) return 0;
+		else return 1;
+	}
+
+	public static Integer compare(Time t1, Time t2)
+	{
+		return compare('' + t1, '' + t2);
+	}
+
+	/**
+	 * check if a Set contains a value
+	 * @param object1 - Object - a Set of objects
+	 * @param object2 - Object - the object to check if its a member of the Set
+	 * @return Boolean - TRUE if the object is a member of the Set
+	 */
+	public static Boolean contains(Object object1, Object object2)
+	{
+		if (object1 == null && object2 == null)
+			return true;
+		else if (object1 == null)
+			return false;
+		else if (object2 == null)
+			return false;
+		else if (object1 instanceof set<Date> && object2 instanceof Date)
+			return ((set<Date>) object1).contains((date) object2);
+		else if (object1 instanceof set<Datetime> && object2 instanceof Datetime)
+			return ((set<Datetime>) object1).contains((Datetime) object2);
+		else if (object1 instanceof set<Double> && object2 instanceof Double)
+			return ((set<Double>) object1).contains((Double) object2);
+		else if (object1 instanceof set<Id> && object2 instanceof Id)
+			return ((set<Id>) object1).contains((Id) object2);
+		else if (object1 instanceof set<Integer> && object2 instanceof Integer)
+			return ((set<Integer>) object1).contains((Integer) object2);
+		else if (object1 instanceof set<Long> && object2 instanceof Long)
+			return ((set<Long>) object1).contains((Long) object2);
+		else if (object1 instanceof set<Object>)
+			return ((set<Object>) object1).contains((Object) object2);
+		else if (object1 instanceof set<Time> && object2 instanceof Time)
+			return ((set<Time>) object1).contains((Time) object2);
+		else if (object1 instanceof set<String> && object2 instanceof String)
+			return ((set<String>) object1).contains((String) object2);
+		else
+				throw new IllegalArgumentException(
+						'Both arguments must be type Date, Datetime, Decimal, Double, ID, Integer, Long, Object, Time, Object or String');
+	}
+
+	public class IllegalArgumentException extends Exception	{}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_Comparator.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_Comparator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_Criteria.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Criteria.cls
@@ -1,0 +1,654 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+public virtual with sharing class fflib_Criteria
+		implements Evaluator
+{
+	// Add brace when generated to SQL
+	private Boolean embraced = false;
+
+	// List to hold all evaluators
+	private List<Evaluator> evaluators;
+
+	// The type of comparator NONE | AND | OR
+	private String comparatorType;
+
+
+	/**
+	 * populate private variables with default settings.
+	 */
+	public fflib_Criteria()
+	{
+		this.evaluators = new List<Evaluator>();
+		this.comparatorType = 'AND';
+	}
+
+	/**
+	 * Changes the default comparator for each criteria to OR
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .orCriteria()
+	 *          .equalTo(Account.Name, 'Example')
+	 *  		.equalTo(Account.AccountNumber, '1234567')
+	 *
+	 *  Evaluates:
+	 *      Name = 'Example' OR AccountNumber = '1234567'
+	 */
+	public fflib_Criteria orCriteria()
+	{
+		this.comparatorType = 'OR';
+		return this;
+	}
+
+	/**
+	 * Changes the default comparator for each criteria to AND.
+	 * By default the comparator is set to AND,
+	 * so this method should only be used in custom implementations extended from fflib_Criteria
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new MyCustomCriteria()
+	 *          .andCriteria()
+	 *          .equalTo(Account.Name, 'Example')
+	 *  		.equalTo(Account.AccountNumber, '1234567')
+	 *
+	 *  Evaluates:
+	 *      Name = 'Example' AND AccountNumber = '1234567'
+	 */
+	public fflib_Criteria andCriteria()
+	{
+		this.comparatorType = 'AND';
+		return this;
+	}
+
+	/**
+	 * Adds a sub criteria with OR comparator
+	 *
+	 * @param subCriteria The condition of the sub criteria
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 * new fflib_Criteria()
+	 *          .equalTo(Account.Name, 'Example')
+	 *          .addOrCriteria(
+	 *              new fflib_Criteria()
+	 *              		.equalTo(Account.AccountNumber, '0001')
+	 *              		.equalTo(Account.AccountNumber, '0002'))
+	 *
+	 *  Evaluates:
+	 *      Account.Name = 'Example' AND (Account.AccountNumber = '0001' OR Account.AccountNumber = '0002')
+	 */
+	public fflib_Criteria addOrCriteria(fflib_Criteria subCriteria)
+	{
+		subCriteria.orCriteria();
+		subCriteria.setEmbraced(true);
+		evaluators.add(subCriteria);
+		return this;
+	}
+
+	/**
+	 * Adds a sub criteria with AND comparator
+	 *
+	 * @param subCriteria The condition of the sub criteria
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 * new fflib_Criteria()
+	 *          .orCriteria()
+	 *          .equalTo(Account.Name, 'Example')
+	 *          .addAndCriteria(
+	 *              new fflib_Criteria()
+	 *              		.equalTo(Account.AccountNumber, '0001')
+	 *              		.equalTo(Account.ShippingCountry, 'USA'))
+	 *
+	 *  Evaluates:
+	 *      Name = 'Example' OR (AccountNumber = '0001' AND ShippingCountry = 'USA')
+	 */
+	public fflib_Criteria addAndCriteria(fflib_Criteria subCriteria)
+	{
+		subCriteria.andCriteria();
+		subCriteria.setEmbraced(true);
+		evaluators.add(subCriteria);
+		return this;
+	}
+
+	/**
+	 * add an equal to criteria comparing a fields value to a given value
+	 *
+	 * @param field The sObjectField to evaluate
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .equalTo(Account.Name, 'Example')
+	 *
+	 * Evaluates:
+	 *      Name = 'Example'
+	 */
+	public fflib_Criteria equalTo(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.EQUALS, value));
+		return this;
+	}
+
+	/**
+	 * add a not equal to criteria while comparing a fields value to a given value
+	 *
+	 * @param field The sObjectField to evaluate
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .notEqualTo(Account.Name, 'Example')
+	 *
+	 * Evaluates:
+	 *      Name != 'Example'
+	 */
+	public fflib_Criteria notEqualTo(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.NOT_EQUALS, value));
+		return this;
+	}
+
+	/**
+	 * Evaluates the stored criteria based on the given SObject
+	 *
+	 * @param record The SObject to evaluate
+	 *
+	 * @return The Boolean result of the evaluated criteria
+	 */
+	public Boolean evaluate(Object record)
+	{
+		if (this.evaluators.isEmpty()) return true;
+
+		Boolean result = !(this.comparatorType == 'OR');
+		for (Evaluator evaluator : evaluators)
+		{
+			Boolean evaluateResult = evaluator.evaluate(record);
+			if (evaluateResult && (this.comparatorType == 'OR' || this.comparatorType == 'NONE'))
+			{
+				return true;
+			}
+			else if (!evaluateResult && this.comparatorType == 'AND')
+			{
+				return false;
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * compares the fields values to be greater or equal to the given value
+	 * Evaluates to false if the field value is null
+	 *
+	 * @param field The field to use its value
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .greaterOrEqualTo(Account.AnnualRevenue, 54321)
+	 *
+	 * Evaluates:
+	 *      AnnualRevenue >= 54321
+	 */
+	public fflib_Criteria greaterOrEqualTo(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.GREATER_THAN_OR_EQUAL_TO, value));
+		return this;
+	}
+
+	/**
+	 * compares the fields values to be greater or equal to the given value
+	 * Evaluates to false if the field value is null
+	 *
+	 * @param field The field to use its value
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .greaterThan(Account.AnnualRevenue, 54321)
+	 *
+	 * Evaluates:
+	 *      AnnualRevenue > 54321
+	 */
+	public fflib_Criteria greaterThan(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.GREATER_THAN, value));
+		return this;
+	}
+
+	/**
+	 * compares the fields values to be less or equal to the given value
+	 * Evaluates to true if the field value is null
+	 *
+	 * @param field The field to use its value
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .lessOrEqualTo(Account.AnnualRevenue, 54321)
+	 *
+	 * Evaluates:
+	 *      AnnualRevenue <= 54321
+	 */
+	public fflib_Criteria lessOrEqualTo(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.LESS_THAN_OR_EQUAL_TO, value));
+		return this;
+	}
+
+
+	/**
+	 * compares the fields values to be greater or equal to the given value
+	 * Evaluates to true if the field value is null
+	 *
+	 * @param field The field to use its value
+	 * @param value The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .lessThan(Account.AnnualRevenue, 54321)
+	 *
+	 * Evaluates:
+	 *      AnnualRevenue < 54321
+	 */
+	public fflib_Criteria lessThan(Schema.SObjectField field, Object value)
+	{
+		evaluators.add(new FieldEvaluator(field, fflib_Operator.LESS_THAN, value));
+		return this;
+	}
+
+	/**
+	 * checks if the given sets contains the fields values
+	 *
+	 * @param field The field to use its value
+	 * @param values The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .inSet(Account.Type, new Set<Object>{'Customer', 'Competitor', 'Partner'})
+	 *
+	 * Evaluates:
+	 *      Account.Type IN ('Customer','Competitor','Partner')
+	 */
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Object> values)
+	{
+		return inSet(field, new Objects(values));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Date> values)
+	{
+		return inSet(field, new Objects(new List<Date>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<DateTime> values)
+	{
+		return inSet(field, new Objects(new List<DateTime>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Decimal> values)
+	{
+		return inSet(field, new Objects(new List<Decimal>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Double> values)
+	{
+		return inSet(field, new Objects(new List<Double>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Id> values)
+	{
+		return inSet(field, new Objects(new List<Id>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Integer> values)
+	{
+		return inSet(field, new Objects(new List<Integer>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<Long> values)
+	{
+		return inSet(field, new Objects(new List<Long>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Set<String> values)
+	{
+		return inSet(field, new Objects(new List<String>(values)));
+	}
+	public fflib_Criteria inSet(Schema.SObjectField field, Objects values)
+	{
+		evaluators.add(new FieldSetEvaluator(field, fflib_Operator.INx, values));
+		return this;
+	}
+
+	/**
+	 * checks if the given sets contains the fields values
+	 *
+	 * @param field The field to use its value
+	 * @param values The value to be compared to the fields value
+	 *
+	 * @return Instance of fflib_Criteria
+	 *
+	 * @example
+	 *  new fflib_Criteria()
+	 *          .notInSet(Account.Type, new Set<Object>{'Customer', 'Competitor', 'Partner'})
+	 *
+	 * Evaluates:
+	 *      Account.Type NOT IN ('Customer','Competitor','Partner')
+	 */
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Date> values)
+	{
+		return notInSet(field, new Objects(new List<Date>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<DateTime> values)
+	{
+		return notInSet(field, new Objects(new List<DateTime>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Decimal> values)
+	{
+		return notInSet(field, new Objects(new List<Decimal>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Double> values)
+	{
+		return notInSet(field, new Objects(new List<Double>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Id> values)
+	{
+		return notInSet(field, new Objects(new List<Id>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Integer> values)
+	{
+		return notInSet(field, new Objects(new List<Integer>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Long> values)
+	{
+		return notInSet(field, new Objects(new List<Long>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<String> values)
+	{
+		return notInSet(field, new Objects(new List<String>(values)));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Set<Object> values)
+	{
+		return notInSet(field, new Objects(values));
+	}
+	public fflib_Criteria notInSet(Schema.SObjectField field, Objects values)
+	{
+		evaluators.add(new FieldSetEvaluator(field, fflib_Operator.NOT_IN, values));
+		return this;
+	}
+
+	/**
+	 * Generates the SOQL equivalent of the criteria provided
+	 *
+	 * @return The "where" part in the SOQL statement
+	 */
+	public String toSOQL()
+	{
+		if (this.evaluators.isEmpty()) return '';
+
+		String result = '';
+		for (Evaluator evaluator : this.evaluators)
+		{
+			if (result != '')
+			{
+				result += ' ' + this.comparatorType + ' ';
+			}
+			result += evaluator.toSOQL();
+		}
+
+		if (this.embraced) result = '(' + result + ')';
+
+		return result;
+	}
+
+	private static String operatorToString(fflib_Operator operator)
+	{
+		if (operator == fflib_Operator.EQUALS)
+			return '=';
+		else if (operator == fflib_Operator.NOT_EQUALS)
+			return '!=';
+		else if (operator == fflib_Operator.LESS_THAN)
+			return '<';
+		else if (operator == fflib_Operator.LESS_THAN_OR_EQUAL_TO)
+			return '<=';
+		else if (operator == fflib_Operator.GREATER_THAN)
+			return '>';
+		else if (operator == fflib_Operator.GREATER_THAN_OR_EQUAL_TO)
+			return '>=';
+		else if (operator == fflib_Operator.LIKEx)
+			return ' like ';
+		else if (operator == fflib_Operator.INx)
+			return ' IN ';
+		else if (operator == fflib_Operator.NOT_IN)
+			return ' NOT IN ';
+		else if (operator == fflib_Operator.INCLUDES)
+			return ' INCLUDES ';
+		else if (operator == fflib_Operator.EXCLUDES)
+			return ' EXCLUDES ';
+		else
+				return null;
+	}
+
+	/**
+	 * Adds braces to the condition when generated to SOQL
+	 *
+	 * @param embraced Braces will be added if set to TRUE
+	 */
+	private void setEmbraced(Boolean embraced)
+	{
+		this.embraced = embraced;
+	}
+
+	/**
+	 * @param value The value to convert
+	 *
+	 * @return Returns the given value converted to literal string
+	 */
+	private static String toLiteral(final Object value)
+	{
+		if (value == null) return 'null';
+
+		if (value instanceof String || value instanceof Id)
+		{
+			String manipulated = (String) value;
+			return '\'' + manipulated + '\'';
+		}
+		else if (value instanceof Boolean ||
+				value instanceof Integer ||
+				value instanceof Long ||
+				value instanceof Double ||
+				value instanceof Decimal)
+		{
+			return '' + value;
+		}
+		else if (value instanceof Date)
+		{
+			return '' + Datetime.newInstance(((Date) value).year(), ((Date) value).month(), ((Date) value).day()).format('yyyy-MM-dd');
+		}
+		else if (value instanceof Datetime)
+		{
+			return '' + ((Datetime) value).format('yyyy-MM-dd') + 'T' + ((Datetime) value).format('HH:mm:ss') + 'Z';
+		}
+
+		throw new CriteriaException(
+				'invalid value; value must a primitive type (String|Id|Boolean|Integer|Long|Double|Decimal|Date|Datetime)'
+		);
+	}
+
+	/**
+	 * @param values The values to convert
+	 *
+	 * @return Returns the given values converted to literal string separated by a comma
+	 */
+	private static String toLiteral(final Objects values)
+	{
+		if (values.isEmpty()) return '';
+
+		String result = '(';
+		for (Object obj : values.getObjects())
+		{
+			if (result != '(')
+			{
+				result += ',';
+			}
+			result += toLiteral(obj);
+		}
+		return result + ')';
+	}
+
+	/**
+	 * Generic criteria handler for comparing against sets
+	 */
+	private class FieldSetEvaluator implements Evaluator
+	{
+		private Schema.SObjectField sObjectField;
+		private Objects values;
+		private fflib_Operator operator;
+
+		public FieldSetEvaluator(Schema.SObjectField sObjectField, fflib_Operator operator, Objects values)
+		{
+			this.sObjectField = sObjectField;
+			this.values = values;
+			this.operator = operator;
+		}
+
+		public Boolean evaluate(Object record)
+		{
+			if (!(record instanceof SObject))
+				throw new CriteriaException('Only records of type SObject can have fieldCriteria');
+
+			Object fieldValue = ((SObject) record).get(this.sObjectField);
+			Boolean isIn = this.values.contains(fieldValue);
+			return ((operator == fflib_Operator.INx && isIn) || (operator == fflib_Operator.NOT_IN && !isIn));
+		}
+
+		public String toSOQL()
+		{
+			return String.format(
+					'{0} {2} {3}',
+					new List<String>
+					{
+							this.sObjectField.getDescribe().getName(),
+							operatorToString(this.operator),
+							toLiteral(this.values)
+					}
+			);
+		}
+	}
+
+	private interface Evaluator
+	{
+		Boolean evaluate(Object obj);
+		String toSOQL();
+	}
+
+	/**
+	 * Generic field Evaluator
+	 */
+	private class FieldEvaluator implements Evaluator
+	{
+		private Schema.SObjectField sObjectField;
+		private Object value;
+		private fflib_Operator operator;
+
+		public FieldEvaluator(Schema.SObjectField sObjectField, fflib_Operator operator, Object value)
+		{
+			this.sObjectField = sObjectField;
+			this.value = value;
+			this.operator = operator;
+		}
+
+		public Boolean evaluate(Object record)
+		{
+			if (!(record instanceof SObject))
+				throw new CriteriaException('Only records of type SObject can have fieldCriteria');
+
+			Object fieldValue = ((SObject) record).get(this.sObjectField);
+
+			return fflib_Comparator.compareTo(fieldValue, operator, this.value);
+		}
+
+		public String toSOQL()
+		{
+			return String.join(
+					new List<String>
+					{
+							this.sObjectField.getDescribe().getName(),
+							operatorToString(this.operator),
+							toLiteral(this.value)
+					},
+					''
+			);
+		}
+	}
+
+	private virtual class Objects
+	{
+		protected List<Object> objects { get; private set; }
+
+		public Objects(Set<Object> objects)
+		{
+			this(new List<Object>(objects));
+		}
+
+		public Objects(List<Object> objects)
+		{
+			this.objects = objects;
+		}
+
+		public Boolean contains(Object value)
+		{
+			return getObjects().contains(value);
+		}
+
+		public Boolean isEmpty()
+		{
+			return (getObjects() == null || getObjects().isEmpty());
+		}
+
+		public List<Object> getObjects()
+		{
+			return this.objects;
+		}
+	}
+
+	/**
+	 * Class exception handler
+	 */
+	public class CriteriaException extends Exception { }
+}

--- a/sfdx-source/apex-common/main/classes/fflib_Criteria.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_Criteria.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_Operator.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Operator.cls
@@ -23,25 +23,20 @@
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
-public interface fflib_ISObjects extends fflib_IObjects
+public enum fflib_Operator
 {
-	/**
-	 * @return Return the SObject records contained in the domain
-	 */
-	List<SObject> getRecords();
+	EQUALS,                   // =
+	NOT_EQUALS,               // !=
+	LESS_THAN,                // <
+	LESS_THAN_OR_EQUAL_TO,    // <=
+	GREATER_THAN,             // >
+	GREATER_THAN_OR_EQUAL_TO, // >=
+	LIKEx,                    // like
 
-	/**
-	 * @return Return the SObject records contained in the domain
-	*/
-	List<SObject> getRecords(fflib_Criteria criteria);
-
-	/**
-	 * @return Return the SObject records ids contained in the domain
-	 */
-	Set<Id> getRecordIds();
-
-	/**
-	 * @return Return the SObjectType of the SObjects contained in the domain
-	 */
-	SObjectType getSObjectType();
+	INCLUDES,                 // includes
+	EXCLUDES,                 // excludes
+	INx,                      // in
+	NOT_IN,                   // not in
+	ANDx,                     // AND
+	ORx                       // OR
 }

--- a/sfdx-source/apex-common/main/classes/fflib_Operator.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_Operator.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -299,6 +299,15 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		this.conditionExpression = conditionExpression;
 		return this;
 	}
+
+	/**
+	 * @param conditionCriteria Sets the WHERE clause to the provided criteria.
+	 */
+	public fflib_QueryFactory setCondition(fflib_Criteria conditionCriteria)
+	{
+		this.conditionExpression = conditionCriteria.toSOQL();
+		return this;
+	}
 	/**
 	 * @returns the current value of the WHERE clause, if any, as set by {@link #setCondition}
 	**/

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -59,6 +59,23 @@ public virtual class fflib_SObjects
 		return (List<SObject>) getObjects();
 	}
 
+	/**
+	 * @param criteria The condition
+	 *
+	 * @return Return the SObject records contained in the domain
+	 */
+	public virtual List<SObject> getRecords(fflib_Criteria criteria)
+	{
+		List<SObject> result = new List<SObject>();
+		for (SObject record : getRecords())
+		{
+			if (!criteria.evaluate(record)) continue;
+
+			result.add(record);
+		}
+		return result;
+	}
+
 	public virtual Set<Id> getRecordIds()
 	{
 		return new Map<Id, SObject>(getRecords()).keySet();

--- a/sfdx-source/apex-common/test/classes/fflib_CriteriaTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_CriteriaTest.cls
@@ -1,0 +1,549 @@
+/**
+ * Copyright (c), FinancialForce.com, inc
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice,
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the FinancialForce.com, inc nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+
+@IsTest(IsParallel=true)
+private class fflib_CriteriaTest
+{
+
+	private static final Integer HIGHER_NUMBER = 98765;
+	private static final Integer A_NUMBER = 54321;
+	private static final Integer SAME_NUMBER = A_NUMBER;
+	private static final Integer LOWER_NUMBER = 0;
+	private static final String A_STRING = 'Example';
+	private static final String SAME_STRING = A_STRING;
+	private static final String ANOTHER_STRING = 'Something Else';
+	private static final String HELLO_WORLD = 'Hello World!';
+	private static final Boolean FAILING = false;
+
+
+	@IsTest
+	static void itShouldEvaluateAnEqualsToCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.andCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.evaluate(new Account(Name = SAME_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAnEqualsToCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.evaluate(new Account(Name = ANOTHER_STRING))
+						== FAILING
+		);
+	}
+	@IsTest
+	static void itShouldEvaluateAnEqualsToCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.evaluate(new Account())
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateANotEqualsToCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notEqualTo(Account.Name, A_STRING)
+						.evaluate(new Account(Name = ANOTHER_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateANotEqualsToCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notEqualTo(Account.Name, A_STRING)
+						.evaluate(new Account(Name = SAME_STRING))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterOrEqualToCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = HIGHER_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterOrEqualToCondition_Equal()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = SAME_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterOrEqualToCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = LOWER_NUMBER))
+						== FAILING
+		);
+	}
+	@IsTest
+	static void itShouldEvaluateAddGreaterOrEqualToCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account())
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterThanCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = HIGHER_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterThanCondition_EqualValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = SAME_NUMBER))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddGreaterThanCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = LOWER_NUMBER))
+						== FAILING
+		);
+	}
+	@IsTest
+	static void itShouldEvaluateAddGreaterThanCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.greaterThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account())
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessOrEqualToCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = LOWER_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessOrEqualToCondition_Equal()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = SAME_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessOrEqualToCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = HIGHER_NUMBER))
+						== FAILING
+		);
+	}
+	@IsTest
+	static void itShouldEvaluateAddLessOrEqualToCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessOrEqualTo(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account())
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessThanCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = LOWER_NUMBER))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessThanCondition_EqualValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = SAME_NUMBER))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessThanCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account(AnnualRevenue = HIGHER_NUMBER))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddLessThanCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.lessThan(Account.AnnualRevenue, A_NUMBER)
+						.evaluate(new Account())
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition_Decimal()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.AnnualRevenue, new Set<Decimal> {1.1, 2.2})
+						.evaluate(new Account(AnnualRevenue = 1.1))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition_Id()
+	{
+		Id idOne = fflib_IDGenerator.generate(Account.SObjectType);
+		Id idTwo = fflib_IDGenerator.generate(Account.SObjectType);
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.Id, new Set<Id> {idOne, idTwo})
+						.evaluate(new Account(Id = idOne))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition_Integer()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.NumberOfEmployees, new Set<Integer> {1, 10})
+						.evaluate(new Account(NumberOfEmployees = 1))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.Type, new Set<String> {A_STRING, HELLO_WORLD})
+						.evaluate(new Account(Type = SAME_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition_ReturningFalse()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.Type, new Set<String> {A_STRING, HELLO_WORLD})
+						.evaluate(new Account(Type = ANOTHER_STRING))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateInSetCondition_NullValues()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.inSet(Account.Type, new Set<String> {A_STRING, HELLO_WORLD})
+						.evaluate(new Account())
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateNotInSetCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notInSet(Account.Name, new Set<String> {A_STRING, HELLO_WORLD})
+						.evaluate(new Account(Name = ANOTHER_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateNotInSetCondition_Failing()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notInSet(Account.Name, new Set<String> {A_STRING, HELLO_WORLD})
+						.evaluate(new Account(Name = SAME_STRING))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateNotInSetCondition_Decimal()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notInSet(Account.AnnualRevenue, new Set<Decimal> {1.1, 2.2})
+						.evaluate(new Account(AnnualRevenue = 3.3))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateNotInSetCondition_Id()
+	{
+		Id idOne = fflib_IDGenerator.generate(Account.SObjectType);
+		Id idTwo = fflib_IDGenerator.generate(Account.SObjectType);
+		Id idThree = fflib_IDGenerator.generate(Account.SObjectType);
+		System.assert(
+				new fflib_Criteria()
+						.notInSet(Account.Id, new Set<Id> {idOne, idTwo})
+						.evaluate(new Account(Id = idThree))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateNotInSetCondition_Integer()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.notInSet(Account.NumberOfEmployees, new Set<Integer> {1, 10})
+						.evaluate(new Account(NumberOfEmployees = 2))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateOrCondition_First()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.evaluate(new Account(Name = A_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateOrCondition_Second()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.evaluate(new Account(Name = ANOTHER_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateOrCondition_Failing()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.evaluate(new Account(Name = HELLO_WORLD))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddOrCondition_First()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.addOrCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.AccountNumber, '001')
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = A_STRING, AccountNumber = '001'))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddOrCondition_Second()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.addOrCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.AccountNumber, '001')
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = A_STRING, AccountNumber = '002'))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddOrCondition_Failing()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.addOrCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.AccountNumber, '001')
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = ANOTHER_STRING, AccountNumber = '001'))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddAndCondition_First()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.addAndCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.Name, HELLO_WORLD)
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = ANOTHER_STRING))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddAndCondition_Second()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.addAndCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.Name, HELLO_WORLD)
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = HELLO_WORLD, AccountNumber = '002'))
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateAddAndCondition_SecondFailing()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.orCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.equalTo(Account.Name, ANOTHER_STRING)
+						.addAndCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.Name, HELLO_WORLD)
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.evaluate(new Account(Name = HELLO_WORLD))
+						== FAILING
+		);
+	}
+
+	@IsTest
+	static void itShouldEvaluateEmptyCondition()
+	{
+		System.assert(
+				new fflib_Criteria()
+						.evaluate(new Account())
+		);
+	}
+
+	@IsTest
+	static void itShouldGenerateQueryString_EqualsToCondition()
+	{
+		System.assertEquals(
+				'Name=\'Example\'',
+				new fflib_Criteria()
+						.andCriteria()
+						.equalTo(Account.Name, A_STRING)
+						.toSOQL()
+		);
+	}
+
+	@IsTest
+	static void itShouldGenerateQueryString_AddOrCondition()
+	{
+		System.assertEquals(
+				'Name=\'Example\' AND (AccountNumber=\'001\' OR AccountNumber=\'002\')',
+				new fflib_Criteria()
+						.equalTo(Account.Name, A_STRING)
+						.addOrCriteria(
+						new fflib_Criteria()
+								.equalTo(Account.AccountNumber, '001')
+								.equalTo(Account.AccountNumber, '002')
+				)
+						.toSOQL()
+		);
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_CriteriaTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_CriteriaTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
A common criteria based filter for domains and SOQL condition generator for Selectors.

Often the same filters are repeated in the domain and the selector classes. The Criteria feature provides a solution for that by extracting the filter conditions into a single reusable criteria class. The filter conditions are made dynamic so that they can be evaluated in run-time, or be converted to a SOQL statement condition.
```
                + - - - - - - - - +
        + - - - | Filter Criteria | - - - +  
        |       + - - - - - - - - +       |
        |                                 | 
        |                                 |
+ - - - - - - - +                 + - - - - - - - +
|    Domain     |                 |    Selector   |
+ - - - - - - - +                 + - - - - - - - +
```
Here is an example on how its used:

The criteria class is the place where all the filter conditions are stored for a single SObjectType.

```apex
public with sharing class AccountCriteria extends fflib_Criteria
{
    public AccountCriteria ShippingCountryEquals(String countryName)
    { 
        equalTo(Schema.Account.ShippingCountry, countryName);
        return this;                
    }
    
    public AccountCriteria NumberOfEmployeesGreaterThan(Integer numberOfEmployees)
    {
        greaterThan(Schema.Account.NumberOfEmployees, numberOfEmployees);
        return this;
    }
}
```

How it can be applied in a Domain class:

```apex
public with sharing class Accounts
        extends fflib_SObjectDomain
        implements IAccounts
{
    private static final Integer LARGE_ACCOUNT_EMPLOYEE_NUMBERS = 500;

    public Accounts getByCountry(String countryName)
    {
        return new Accounts(
                getRecords(
                        new AccountCriteria().ShippingCountryEquals(countryName)
                )
        );
    }
    
    public Accounts getByNumberOfEmployeesGreaterThan(Integer numberOfEmployees)
    {
        return new Accounts(
                getRecords(
                       new AccountCriteria().NumberOfEmployeesGreaterThan(numberOfEmployees)
                )
        );
    }
    
    public Accounts getByLargeAccountsInCountry(String countryName)
    {
        return new Accounts(
                getRecords(
                       new AccountCriteria()
                               .ShippingCountryEquals(countryName)
                               .NumberOfEmployeesGreaterThan(numberOfEmployees)
                )
        );
    }
}
```
In this example we see three filters; one for country, another for checking minimal number of employees and a third that combines the first two.
It is important not to have a filter with too many conditions. 
One filter criteria condition per method is ideal to have maximum flexibility and a high chance on code-reuse.


How the same filters can be used in the Selector class:

```apex
public with sharing class AccountsSelector
        extends fflib_SObjectSelector
        implements IAccountsSelector
{
    ...
    public List<Account> selectByCountryWithMinimalNumberOfEmployees(String country, Integer minimalNumberOfEmployees)
    {
        return (List<Account>)  Database.query(
                newQueryFactory()
                        .setCondition(
                                new AccountCriteria()
                                        .ShippingCountryEquals(country)
                                        .NumberOfEmployeesGreaterThan(minimalNumberOfEmployees)
        );
    }
    ...
}
```

With this change developers can avoid a lot of code duplications.
Hope you like it!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/313)
<!-- Reviewable:end -->
