### PR TITLE
#315 Address the unit test failures resulting from the removal of the "Read Only" Profile

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
@@ -26,7 +26,76 @@
 
 @isTest
 private class fflib_SecurityUtilsTest {
+
+	@TestSetup
+	static void testSetup() {
+		// #315 Create a Permission Set that grants "Read" access to Account, Contact and Lead. We will use this in
+		// Spring '21 orgs that lack the "Read Only" Profile. See:
+		// https://help.salesforce.com/articleView?id=release-notes.rn_profiles_and_perms_read_only_new.htm&release=230&type=5).
+		PermissionSet ps = new PermissionSet(Label = 'Read Only Permission Set', Name = 'ReadOnlyPermissionSet');
+		insert ps;
+
+		// Grant Read access to the SObjects we use for CRUD tests
+		List<ObjectPermissions> objectPerms = new List<ObjectPermissions>();
+		objectPerms.add(createObjectPermissions(ps.Id, 'Account', false, true, false, false));
+		objectPerms.add(createObjectPermissions(ps.Id, 'Contact', false, true, false, false));
+		objectPerms.add(createObjectPermissions(ps.Id, 'Lead', false, true, false, false));
+		insert objectPerms;
+
+		// Grant Read/Edit access to the SObject fields we use for FLS tests
+		List<FieldPermissions> fieldPerms = new List<FieldPermissions>();
+		fieldPerms.add(createFieldPermissions(ps.Id, 'Contact', 'Birthdate', true, false));
+		fieldPerms.add(createFieldPermissions(ps.Id, 'Contact', 'Email', true, false));
+		insert fieldPerms;
+	}
+
+	static Profile getProfile(String profileName) {
+		return [SELECT Id, Name FROM Profile WHERE Name = :profileName];
+	}
+
+	static ObjectPermissions createObjectPermissions(
+		Id permSetId, String objectType, Boolean canCreate, Boolean canRead,  Boolean canUpdate, Boolean canDelete
+	) {
+		return new ObjectPermissions(
+			ParentId = permSetId,
+			SobjectType = objectType,
+			PermissionsCreate = canCreate,
+			PermissionsRead = canRead,
+			PermissionsEdit = canUpdate,
+			PermissionsDelete = canDelete
+		);
+	}
+
+	static FieldPermissions createFieldPermissions(
+		Id permSetId, String objectType, String fieldName, Boolean canRead, Boolean canEdit
+	) {
+		return new FieldPermissions(
+			ParentId = permSetId,
+			SobjectType = objectType,
+			Field = objectType + '.' + fieldName,
+			PermissionsRead = canRead,
+			PermissionsEdit = canEdit
+		);
+	}
+
 	static User setupTestUser(String profileName){
+		Profile p;
+		Boolean usedMinimumAccessProfile = false;
+		if (profileName == 'Read Only') {
+			try {
+				p = getProfile(profileName);
+			} catch (QueryException ex) {
+				if (ex.getMessage().contains('List has no rows for assignment to SObject')) {
+					// #315 If the "Read Only" Profile is absent, then assume it's a Spring '21 org and see if there's a
+					// "Minimum Access - Salesforce" Profile we can use instead.
+					p = getProfile('Minimum Access - Salesforce');
+					usedMinimumAccessProfile = true;
+				}
+			}
+		} else {
+			p = getProfile(profileName);
+		}
+
 		//username global uniqueness is still enforced in tests 
 		//make sure we get something unique to avoid issues with parallel tests
 		String uniqueness = DateTime.now()+':'+Math.random();
@@ -35,8 +104,7 @@ private class fflib_SecurityUtilsTest {
 		}catch(Exception e){
 			uniqueness += e.getStackTraceString(); //includes the top level test method name without having to pass it
 		}
-		Profile p = [SELECT id, Name FROM Profile WHERE Name = :profileName];
-		User result = new User(
+		User usr = new User(
 			username=UserInfo.getUserId()+'.'+uniqueness.HashCode()+'@'+UserInfo.getOrganizationId()+'.sfdcOrg',
 			alias = 'testExec',
 			email='apextests@example.com',
@@ -47,8 +115,15 @@ private class fflib_SecurityUtilsTest {
 			profileid = p.Id,
 			timezonesidkey='America/Los_Angeles'
 		);
-		insert result;
-		return result;
+		insert usr;
+
+		if (usedMinimumAccessProfile) {
+			// #315 We need to assign the Perm Set to grant Account "Read" access
+			PermissionSet accountReadPS = [SELECT Id FROM PermissionSet WHERE Name = 'ReadOnlyPermissionSet'];
+			PermissionSetAssignment psa = new PermissionSetAssignment(AssigneeId = usr.Id, PermissionSetId = accountReadPS.Id);
+			insert psa;
+		}
+		return usr;
 	}
 
 	@isTest
@@ -176,8 +251,8 @@ private class fflib_SecurityUtilsTest {
 						Contact.SObjectType,
 						new List<String>{
 							'LastName',
-							'accountId',
-							'ownerId'
+							'eMaiL',
+							'BirthDATE'
 						}
 					);
 				}catch(fflib_SecurityUtils.SecurityException e){


### PR DESCRIPTION
The summary here is that I create an ad-hoc Permission Set that grants read access to Account, Contact and Lead in the testSetup method. Then, I modified the existing setupTestUser method so that if the "Read Only" Profile is absent from the org, it assumes we're in a Spring '21 org, and it uses the "Minimum Access - Salesforce" Profile instead of "Read Only". It then assigns the ad-hoc Permission Set to the User, because "Minimum Access - Salesforce", doesn't grant read access to any standard objects. I also had to create FieldPermissions to grant read access to a couple of fields on Contact in order to satisfy the FLS checks in the readonly_objectAndField_access test method.