### PR TITLE
Add unit of work partial success

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_DatabaseOperation.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_DatabaseOperation.cls
@@ -1,0 +1,10 @@
+public enum fflib_DatabaseOperation {
+
+	DATABASE_INSERT,
+
+	DATABASE_UPDATE,
+
+	DATABASE_DELETE,
+
+	DATABASE_UNDELETE
+}

--- a/sfdx-source/apex-common/main/classes/fflib_DatabaseOperation.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_DatabaseOperation.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_DmlOperation.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_DmlOperation.cls
@@ -1,0 +1,104 @@
+/*
+* This class serves as a container of DML operations performed on the database.
+*
+* The purpose of this is to keep track of what operations have been committed to the database
+* and their results. This way, when the commitWork method of the UnitOfWorkPartialSuccess class is called,
+* the caller will receive back a container of what happened with the committal of the work such as
+* the SObject the operation was performed on, the result of the committal, and the ability to mark
+* the DML operation for a rollback if the committal were to fail.
+ */
+
+public with sharing class fflib_DmlOperation {
+
+	private final fflib_DatabaseOperation databaseOperation;
+	private final SObject record;
+	private SObject originalRecord;
+	private fflib_DmlOperationResult dmlOperationResult;
+	private fflib_DmlOperation rollbackDmlOperation;
+
+	/**
+	 * Constructs a new instance of a DmlOperation for tracking DML Operations from UnitOfWork
+	 *
+	 * @param record SObject to construct this instance with
+	 * @param databaseOperation DatabaseOperation to construct this instance with
+	 */
+	public fflib_DmlOperation(SObject record, fflib_DatabaseOperation databaseOperation) {
+		if (record == null) {
+			throw new IllegalArgumentException('Invalid SObject.');
+		}
+		this.databaseOperation = databaseOperation;
+		this.record = record;
+	}
+
+	/**
+	 * Gets Database Operation this class was constructed with
+	 *
+	 * @return Database operation
+	 */
+	public fflib_DatabaseOperation getDatabaseOperation() {
+		return databaseOperation;
+	}
+
+	/**
+	 * Gets SObject reference this class was constructed with
+	 *
+	 * @return SObject
+	 */
+	public SObject getSObject() {
+		return record;
+	}
+
+	/**
+	 * Gets original SObject that was set
+	 *
+	 * @return Original SObject
+	 */
+	public SObject getOriginalSObject() {
+		return originalRecord;
+	}
+
+	/**
+	 * Sets original SObject for update rollback purposes
+	 *
+	 * @param record SObject to rollback to
+	 */
+	public void setOriginalSObject(SObject record) {
+		this.originalRecord = record;
+	}
+
+	/**
+	 * Sets DML Operation Result that occurs after commitWork is called from a unit of work
+	 *
+	 * @param dmlOperationResult DML Operation Result to set
+	 */
+	public void setDmlOperationResult(fflib_DmlOperationResult dmlOperationResult) {
+		this.dmlOperationResult = dmlOperationResult;
+	}
+
+	/**
+	 * Gets the DML Operation Result that was set
+	 *
+	 * @return DML Operation Result
+	 */
+	public fflib_DmlOperationResult getDmlOperationResult() {
+		return dmlOperationResult;
+	}
+
+	/**
+	 * Sets Rollback DML Operation for rolling back the parent DML operation
+	 *
+	 * @param dmlOperation DML Operation to set
+	 */
+	public void setRollbackDmlOperation(fflib_DmlOperation rollbackDmlOperation) {
+		this.rollbackDmlOperation = rollbackDmlOperation;
+	}
+
+	/**
+	 * Gets the rollback DML Operation that was set
+	 *
+	 * @return DML operation
+	 */
+	public fflib_DmlOperation getRollbackDmlOperation() {
+		return rollbackDmlOperation;
+	}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_DmlOperation.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_DmlOperation.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_DmlOperationResult.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_DmlOperationResult.cls
@@ -1,0 +1,80 @@
+/*
+* This class serves as a container of the result of a DML operation.
+*
+* This class generisizes the use of the plethora of DML result classes that are a part of Apex such as
+* SaveResult, DeleteResult, and UndeleteResult
+ */
+
+public with sharing class fflib_DmlOperationResult {
+
+	private final Id recordId;
+	private final Boolean success;
+	private final List<Database.Error> errors;
+
+	/**
+	 * Constructs a new DML operation result from a result of an insert or update database transaction
+	 *
+	 * @param saveResult Save result from a database transaction
+	 */
+	public fflib_DmlOperationResult(Database.SaveResult saveResult) {
+		this(saveResult.getId(), saveResult.isSuccess(), saveResult.getErrors());
+	}
+
+	/**
+	 * Constructs a new DML operation result from a result of a delete database transaction
+	 *
+	 * @param saveResult Delete result from a database transaction
+	 */
+	public fflib_DmlOperationResult(Database.DeleteResult deleteResult) {
+		this(deleteResult.getId(), deleteResult.isSuccess(), deleteResult.getErrors());
+	}
+
+	/**
+	 * Constructs a new DML operation result from a result of an undelete database transaction
+	 *
+	 * @param saveResult Undelete result from a database transaction
+	 */
+	public fflib_DmlOperationResult(Database.UndeleteResult undeleteResult) {
+		this(undeleteResult.getId(), undeleteResult.isSuccess(), undeleteResult.getErrors());
+	}
+
+	/**
+	 * Constructs a DML operation result
+	 *
+	 * @param recordId Id of an SObject
+	 * @param success Boolean if result was successful or not
+	 * @param errors List of database errors from a database transaction
+	 */
+	public fflib_DmlOperationResult(Id recordId, Boolean success, List<Database.Error> errors) {
+		this.recordId = recordId;
+		this.success = success;
+		this.errors = errors;
+	}
+
+	/**
+	 * Returns SObject Id this class was constructed with
+	 *
+	 * @return SObject Id
+	 */
+	public Id getId() {
+		return recordId;
+	}
+
+	/**
+	 * Returns boolean this class was constructed with
+	 *
+	 * @return success boolean
+	 */
+	public Boolean isSuccess() {
+		return success;
+	}
+
+	/**
+	 * Returns database errors this class was constructed with
+	 *
+	 * @return Database errors from a database transaction
+	 */
+	public List<Database.Error> getErrors() {
+		return errors;
+	}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_DmlOperationResult.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_DmlOperationResult.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -594,7 +594,7 @@ public virtual class fflib_SObjectUnitOfWork
     /**
      * Takes all the work that has been registered with the UnitOfWork and commits it to the database
      **/
-	public void commitWork()
+	public virtual void commitWork()
 	{
 		Savepoint sp = Database.setSavepoint();
 		Boolean wasSuccessful = false;
@@ -773,6 +773,20 @@ public virtual class fflib_SObjectUnitOfWork
 					)
 			);
 		}
+	}
+
+	/**
+	 * Clears the collections used by the class so that it can be used as if newly instantiated.
+	 */
+	public virtual void reset()
+	{
+		for (Schema.SObjectType sObjectType : m_sObjectTypes)
+		{
+			// register the type
+			handleRegisterType(sObjectType);
+		}
+
+		m_relationships.put(Messaging.SingleEmailMessage.class.getName(), new Relationships());
 	}
 
     private class Relationships

--- a/sfdx-source/apex-common/main/classes/fflib_UnitOfWorkPartialSuccess.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_UnitOfWorkPartialSuccess.cls
@@ -1,0 +1,437 @@
+/*
+* Behaves similarly to SObjectUnitOfWork, but allows for partial success results from committing to
+* the database.
+*
+* Basically, this has allOrNothing set to false for DML operations. This will also return the DmlResults
+* back to the commitWork caller in the same order in which they were registered.
+ */
+
+public with sharing class fflib_UnitOfWorkPartialSuccess extends fflib_SObjectUnitOfWork {
+
+	private PartialSuccessDml partialDml;
+	private Map<fflib_DatabaseOperation, List<fflib_DmlOperation>> dmlOperationsByDatabaseOperation;
+	private Map<SObjectType, List<SObject>> undeleteSObjectsBySObjectType;
+
+	/**
+   * Constructs a new UnitOfWork to support work against the given object list
+   *
+   * @param sObjectList A list of objects given in dependency order (least dependent first)
+   */
+	public fflib_UnitOfWorkPartialSuccess(List<SObjectType> types) {
+		super(types);
+		initialize();
+	}
+
+	private void initialize() {
+		partialDml = new PartialSuccessDml();
+		undeleteSObjectsBySObjectType = new Map<SObjectType, List<SObject>>();
+		for (SObjectType sObjectType : m_sObjectTypes) {
+			undeleteSObjectsBySObjectType.put(sObjectType, new List<SObject>());
+		}
+
+		dmlOperationsByDatabaseOperation = new Map<fflib_DatabaseOperation, List<fflib_DmlOperation>>();
+		for (fflib_DatabaseOperation databaseOperation : fflib_DatabaseOperation.values()) {
+			dmlOperationsByDatabaseOperation.put(databaseOperation, new List<fflib_DmlOperation>());
+		}
+	}
+
+	/**
+     * Register a newly created SObject instance to be inserted when commitWork is called
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     *
+     * @return DML operation instance
+     **/
+	public fflib_DmlOperation registerNewDmlOperation(SObject record) {
+		return registerNewDmlOperation(record, null, null);
+	}
+
+	/**
+	 * Register a list of newly created SObject instances to be inserted when commitWork is called
+	 *
+	 * @param records A list of newly created SObject instances to be inserted during commitWork
+	 *
+	 * @return A list of DML operation instances
+	 **/
+	public List<fflib_DmlOperation> registerNewDmlOperations(List<SObject> records) {
+		List<fflib_DmlOperation> dmlOperations = new List<fflib_DmlOperation>();
+		for (SObject record : records) {
+			dmlOperations.add(registerNewDmlOperation(record, null, null));
+		}
+		return dmlOperations;
+	}
+
+	/**
+     * Register a newly created SObject instance to be inserted when commitWork is called,
+     *   you may also provide a reference to the parent record instance (should also be registered as new separately).
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
+     * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separately)
+     *
+     * @return DML operation instance
+     **/
+	public fflib_DmlOperation registerNewDmlOperation(SObject record, SObjectField relatedToParentField,
+			SObject relatedToParentRecord) {
+		if (record.Id != null) {
+			throw new UnitOfWorkException('Only new records can be registered as new.');
+		}
+		String sObjectType = record.getSObjectType().getDescribe().getName();
+		if (!m_newListByType.containsKey(sObjectType)) {
+			throw new UnitOfWorkException(
+					'SObjectType ' + sObjectType + ' is not supported by this unit of work.');
+		}
+
+		m_newListByType.get(sObjectType).add(record);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(record, fflib_DatabaseOperation.DATABASE_INSERT);
+		dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_INSERT).add(dmlOperation);
+
+		if (relatedToParentRecord != null && relatedToParentField != null) {
+			registerRelationship(record, relatedToParentField, relatedToParentRecord);
+		}
+		return dmlOperation;
+	}
+
+	/**
+     * Register an existing record to be updated during the commitWork method
+     *
+     * @param record An existing record
+     *
+     * @return DML operation instance
+     **/
+	public fflib_DmlOperation registerDirtyDmlOperation(SObject record) {
+		return registerDirtyDmlOperation(record, null, null);
+	}
+
+	/**
+	 * Register a list of SObject instances to be updated when commitWork is called
+	 *
+	 * @param records A list of newly created SObject instances to be inserted during commitWork
+	 *
+	 * @return DML operation instance
+	 **/
+	public List<fflib_DmlOperation> registerDirtyDmlOperations(List<SObject> records) {
+		List<fflib_DmlOperation> dmlOperations = new List<fflib_DmlOperation>();
+		for (SObject record : records) {
+			dmlOperations.add(registerDirtyDmlOperation(record, null, null));
+		}
+		return dmlOperations;
+	}
+
+	/**
+     * Register an existing record to be updated when commitWork is called,
+     *   you may also provide a reference to the parent record instance (should also be registered as new separately)
+     *
+     * @param record A newly created SObject instance to be inserted during commitWork
+     * @param relatedToParentField A SObjectField reference to the child field that associates the child record with its parent
+     * @param relatedToParentRecord A SObject instance of the parent record (should also be registered as new separately)
+     *
+     * @return DML operation instance
+     **/
+	public fflib_DmlOperation registerDirtyDmlOperation(SObject record, SObjectField relatedToParentField,
+			SObject relatedToParentRecord) {
+		if (record.Id == null) {
+			throw new UnitOfWorkException('Only existing records can be registered as dirty.');
+		}
+
+		String sObjectType = record.getSObjectType().getDescribe().getName();
+		if (!m_dirtyMapByType.containsKey(sObjectType)) {
+			throw new UnitOfWorkException(
+					'SObjectType ' + sObjectType + ' is not supported by this unit of work.');
+		}
+
+		m_dirtyMapByType.get(sObjectType).put(record.Id, record);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(record, fflib_DatabaseOperation.DATABASE_UPDATE);
+		dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_UPDATE).add(dmlOperation);
+
+		if (relatedToParentRecord != null && relatedToParentField != null) {
+			registerRelationship(record, relatedToParentField, relatedToParentRecord);
+		}
+		return dmlOperation;
+	}
+
+	/**
+	* Register an existing record to be deleted during the commitWork method
+	*
+	* @param record An existing record
+	 *
+	 * @return DML operation instance
+	**/
+	public fflib_DmlOperation registerDeleteDmlOperation(SObject record) {
+		if (record.Id == null) {
+			throw new UnitOfWorkException('Only existing records can be registered for deletion.');
+		}
+
+		String sObjectType = record.getSObjectType().getDescribe().getName();
+		if (!m_deletedMapByType.containsKey(sObjectType)) {
+			throw new UnitOfWorkException(
+					'SObjectType ' + sObjectType + ' is not supported by this unit of work.');
+		}
+
+		m_deletedMapByType.get(sObjectType).put(record.Id, record);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(record, fflib_DatabaseOperation.DATABASE_DELETE);
+		dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_DELETE).add(dmlOperation);
+
+		return dmlOperation;
+	}
+
+	/**
+	 * Register a list of existing records to be deleted during the commitWork method
+	 *
+	 * @param records A list of existing records
+	 *
+	 * @return DML operation instance
+	 **/
+	public List<fflib_DmlOperation> registerDeleteDmlOperations(List<SObject> records) {
+		List<fflib_DmlOperation> dmlOperations = new List<fflib_DmlOperation>();
+		for (SObject record : records) {
+			dmlOperations.add(registerDeleteDmlOperation(record));
+		}
+		return dmlOperations;
+	}
+
+	/**
+	 * Register a deleted record to be undeleted in the commitWork method
+	 *
+	 * @param record A deleted record
+	 *
+	 * @return DML operation instance
+	 */
+	public fflib_DmlOperation registerUndeleteDmlOperation(SObject record) {
+		if (record.Id == null) {
+			throw new UnitOfWorkException(
+					'Only previously deleted records can be registered for undeletion.'
+			);
+		}
+
+		SObjectType sObjectType = record.getSObjectType();
+		if (!undeleteSObjectsBySObjectType.containsKey(sObjectType)) {
+			throw new UnitOfWorkException(
+					'SObjectType ' + sObjectType + ' is not supported by this unit of work.');
+		}
+
+		undeleteSObjectsBySObjectType.get(sObjectType).add(record);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(record, fflib_DatabaseOperation.DATABASE_UNDELETE);
+		dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_UNDELETE)
+				.add(dmlOperation);
+
+		return dmlOperation;
+	}
+
+	/**
+	 * Register deleted records to be undeleted in the commitWork method
+	 *
+	 * @param records A list of records to be undeleted
+	 *
+	 * @return A list of DML operations
+	 */
+	public List<fflib_DmlOperation> registerUndeleteDmlOperations(List<SObject> records) {
+		List<fflib_DmlOperation> dmlOperations = new List<fflib_DmlOperation>();
+		for (SObject record : records) {
+			dmlOperations.add(registerUndeleteDmlOperation(record));
+		}
+		return dmlOperations;
+	}
+
+	/**
+	 * Register a DML Operation to rollback in the commitWork method
+	 *
+	 * @param dmlOperation A DML operation instance
+	 */
+	public void registerRollback(fflib_DmlOperation dmlOperation) {
+		if (dmlOperation == null) {
+			throw new IllegalArgumentException('Invalid DML operation.');
+		}
+		if (dmlOperation.getDmlOperationResult() == null ||
+				!dmlOperation.getDmlOperationResult().isSuccess()) {
+			return;
+		}
+
+		fflib_DmlOperation rollbackDmlOperation;
+		if (dmlOperation.getDatabaseOperation() == fflib_DatabaseOperation.DATABASE_INSERT) {
+			rollbackDmlOperation = registerDeleteDmlOperation(dmlOperation.getSObject());
+			dmlOperation.setRollbackDmlOperation(rollbackDmlOperation);
+		} else if (dmlOperation.getDatabaseOperation() == fflib_DatabaseOperation.DATABASE_UPDATE) {
+			rollbackDmlOperation = registerDirtyDmlOperation(dmlOperation.getOriginalSObject());
+			dmlOperation.setRollbackDmlOperation(rollbackDmlOperation);
+		} else if (dmlOperation.getDatabaseOperation() == fflib_DatabaseOperation.DATABASE_DELETE) {
+			rollbackDmlOperation = registerUndeleteDmlOperation(dmlOperation.getSObject());
+			dmlOperation.setRollbackDmlOperation(rollbackDmlOperation);
+		} else if (dmlOperation.getDatabaseOperation() == fflib_DatabaseOperation.DATABASE_UNDELETE) {
+			rollbackDmlOperation = registerDeleteDmlOperation(dmlOperation.getSObject());
+			dmlOperation.setRollbackDmlOperation(rollbackDmlOperation);
+		}
+	}
+
+	/**
+	 * Register a list of DML Operations to rollback in the commitWork method
+	 *
+	 * @param dmlOperations A list of DML operation instances
+	 */
+	public void registerRollbacks(List<fflib_DmlOperation> dmlOperations) {
+		for (fflib_DmlOperation dmlOperation : dmlOperations) {
+			registerRollback(dmlOperation);
+		}
+	}
+
+	/**
+     * Takes all the work that has been registered with the UnitOfWork and commits it to the database.
+     * Allows for partial success of DML operations so that it does not fail if one of the SObjects fail to be committed.
+     **/
+	public override void commitWork() {
+		doCommitWorkPartialSuccess();
+	}
+
+	private void doCommitWorkPartialSuccess() {
+		insertDmlByType();
+		updateDmlByType();
+		deleteDmlByType();
+		undeleteDmlByType();
+		reset();
+	}
+
+	private void insertDmlByType() {
+		for (SObjectType type : m_sObjectTypes) {
+			String typeName = fflib_SObjectDescribe.getDescribe(type).getDescribe().getName();
+			m_relationships.get(typeName).resolve();
+
+			List<SObject> sObjectsToInsert = m_newListByType.get(typeName);
+			List<Database.SaveResult> saveResults = partialDml.dmlInsert(sObjectsToInsert);
+			List<fflib_DmlOperation> dmlOperations = getDmlOperationsBySObjectType(
+					type,
+					dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_INSERT)
+			);
+			setDmlOperationResults(saveResults, dmlOperations);
+		}
+	}
+
+	private List<fflib_DmlOperation> getDmlOperationsBySObjectType(
+			SObjectType sObjectType,
+			List<fflib_DmlOperation> originalDmlOperations
+	) {
+		List<fflib_DmlOperation> dmlOperationsToReturn = new List<fflib_DmlOperation>();
+		for (fflib_DmlOperation dmlOperation : originalDmlOperations) {
+			if (dmlOperation.getSObject().getSObjectType() == sObjectType) {
+				dmlOperationsToReturn.add(dmlOperation);
+			}
+		}
+
+		return dmlOperationsToReturn;
+	}
+
+	private void setDmlOperationResults(
+			List<Database.SaveResult> saveResults,
+			List<fflib_DmlOperation> dmlOperations) {
+		for (Integer i = 0; i < saveResults.size(); i++) {
+			fflib_DmlOperationResult dmlOperationResult =
+					new fflib_DmlOperationResult(saveResults[i]);
+			dmlOperations[i].setDmlOperationResult(dmlOperationResult);
+		}
+	}
+
+	private void updateDmlByType() {
+		for (SObjectType type : m_sObjectTypes) {
+			String typeName = fflib_SObjectDescribe.getDescribe(type).getDescribe().getName();
+
+			List<SObject> sObjectsToUpdate = m_dirtyMapByType.get(typeName).values();
+			List<Database.SaveResult> saveResults = partialDml.dmlUpdate(sObjectsToUpdate);
+
+			List<fflib_DmlOperation> dmlOperations = getDmlOperationsBySObjectType(
+					type,
+					dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_UPDATE)
+			);
+			setDmlOperationResults(saveResults, dmlOperations);
+		}
+	}
+
+	private void deleteDmlByType() {
+		Integer index = m_sObjectTypes.size() - 1;
+		while (index >= 0) {
+			SObjectType sObjectType = m_sObjectTypes.get(index--);
+			String typeName = fflib_SObjectDescribe.getDescribe(sObjectType).getDescribe().getName();
+			List<SObject> sObjectsToDelete = m_deletedMapByType.get(typeName).values();
+			List<Database.DeleteResult> deleteResults = partialDml.dmlDelete(sObjectsToDelete);
+
+			List<fflib_DmlOperation> dmlOperations = getDmlOperationsBySObjectType(
+					sObjectType,
+					dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_DELETE)
+			);
+			setDmlOperationResults(deleteResults, dmlOperations);
+		}
+	}
+
+	private void setDmlOperationResults(
+			List<Database.DeleteResult> deleteResults,
+			List<fflib_DmlOperation> dmlOperations) {
+		for (Integer i = 0; i < deleteResults.size(); i++) {
+			fflib_DmlOperationResult dmlOperationResult =
+					new fflib_DmlOperationResult(deleteResults[i]);
+			dmlOperations[i].setDmlOperationResult(dmlOperationResult);
+		}
+	}
+
+	private void undeleteDmlByType() {
+		for (SObjectType type : m_sObjectTypes) {
+			List<SObject> sObjectsToUndelete = undeleteSObjectsBySObjectType.get(type);
+			List<Database.UndeleteResult> undeleteResults = partialDml.dmlUndelete(sObjectsToUndelete);
+			List<fflib_DmlOperation> dmlOperations = getDmlOperationsBySObjectType(
+					type,
+					dmlOperationsByDatabaseOperation.get(fflib_DatabaseOperation.DATABASE_UNDELETE)
+			);
+			setDmlOperationResults(undeleteResults, dmlOperations);
+		}
+	}
+	private void setDmlOperationResults(
+			List<Database.UndeleteResult> undeleteResults,
+			List<fflib_DmlOperation> dmlOperations) {
+		for (Integer i = 0; i < undeleteResults.size(); i++) {
+			fflib_DmlOperationResult dmlOperationResult =
+					new fflib_DmlOperationResult(undeleteResults[i]);
+			dmlOperations[i].setDmlOperationResult(dmlOperationResult);
+		}
+	}
+
+	/**
+	 * Resets the member variables so that the class can be used as if newly instantiated
+	 */
+	public override void reset() {
+		super.reset();
+		initialize();
+	}
+
+	/**
+	 * Interface for partial DML interactions with the database
+	 */
+	public interface IPartialDml {
+
+		List<Database.SaveResult> dmlInsert(List<SObject> sObjects);
+
+		List<Database.SaveResult> dmlUpdate(List<SObject> sObjects);
+
+		List<Database.DeleteResult> dmlDelete(List<SObject> sObjects);
+
+		List<Database.UndeleteResult> dmlUndelete(List<SObject> sObjects);
+	}
+
+	private class PartialSuccessDml implements IPartialDml {
+		public List<Database.SaveResult> dmlInsert(List<SObject> sObjects) {
+			return Database.insert(sObjects, false);
+		}
+
+		public List<Database.SaveResult> dmlUpdate(List<SObject> sObjects) {
+			return Database.update(sObjects, false);
+		}
+
+		public List<Database.DeleteResult> dmlDelete(List<SObject> sObjects) {
+			return Database.delete(sObjects, false);
+		}
+
+		public List<Database.UndeleteResult> dmlUndelete(List<SObject> sObjects) {
+			return Database.undelete(sObjects, false);
+		}
+	}
+}

--- a/sfdx-source/apex-common/main/classes/fflib_UnitOfWorkPartialSuccess.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_UnitOfWorkPartialSuccess.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_DatabaseOperationTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_DatabaseOperationTest.cls
@@ -1,0 +1,12 @@
+@IsTest
+private class fflib_DatabaseOperationTest {
+
+	@IsTest
+	static void databaseOperations_DatabaseOperations_ReturnDatabaseOperations() {
+		// Assert
+		System.assertEquals('DATABASE_INSERT', fflib_DatabaseOperation.DATABASE_INSERT.name());
+		System.assertEquals('DATABASE_UPDATE', fflib_DatabaseOperation.DATABASE_UPDATE.name());
+		System.assertEquals('DATABASE_DELETE', fflib_DatabaseOperation.DATABASE_DELETE.name());
+		System.assertEquals('DATABASE_UNDELETE', fflib_DatabaseOperation.DATABASE_UNDELETE.name());
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_DatabaseOperationTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_DatabaseOperationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_DmlOperationResultTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_DmlOperationResultTest.cls
@@ -1,0 +1,288 @@
+@IsTest
+private class fflib_DmlOperationResultTest {
+
+	@IsTest
+	static void constructor_SaveResult_NewInstance() {
+		// Arrange
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"0013000000abcde"}', Database.SaveResult.class);
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		Test.stopTest();
+
+		// Assert
+		System.assertNotEquals(null, dmlOperationResult);
+	}
+
+	@IsTest
+	static void constructor_DeleteResult_NewInstance() {
+		// Arrange
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":true,"id":"0013000000abcde"}', Database.DeleteResult.class);
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+		Test.stopTest();
+
+		// Assert
+		System.assertNotEquals(null, dmlOperationResult);
+	}
+
+	@IsTest
+	static void constructor_UndeleteResult_NewInstance() {
+		// Arrange
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":true,"id":"0013000000abcde"}', Database.UndeleteResult.class);
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+		Test.stopTest();
+
+		// Assert
+		System.assertNotEquals(null, dmlOperationResult);
+	}
+
+	@IsTest
+	static void getId_SaveResult_ReturnId() {
+		// Arrange
+		Id sObjectId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + sObjectId + '"}', Database.SaveResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+
+		// Act
+		Test.startTest();
+		Id actualId = dmlOperationResult.getId();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(sObjectId, actualId);
+	}
+
+	@IsTest
+	static void getId_DeleteResult_ReturnId() {
+		// Arrange
+		Id sObjectId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + sObjectId + '"}', Database.DeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+
+		// Act
+		Test.startTest();
+		Id actualId = dmlOperationResult.getId();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(sObjectId, actualId);
+	}
+
+	@IsTest
+	static void getId_UndeleteResult_ReturnId() {
+		// Arrange
+		Id sObjectId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + sObjectId + '"}', Database.UndeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+
+		// Act
+		Test.startTest();
+		Id actualId = dmlOperationResult.getId();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(sObjectId, actualId);
+	}
+
+	@IsTest
+	static void isSuccess_SuccessfulSaveResult_ReturnTrue() {
+		// Arrange
+		Boolean success = true;
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.SaveResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(isSuccess);
+	}
+
+	@IsTest
+	static void isSuccess_UnsuccessfulSaveResult_ReturnFalse() {
+		// Arrange
+		Boolean success = false;
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.SaveResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(!isSuccess);
+	}
+
+	@IsTest
+	static void isSuccess_SuccessfulDeleteResult_ReturnTrue() {
+		// Arrange
+		Boolean success = true;
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.DeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(isSuccess);
+	}
+
+	@IsTest
+	static void isSuccess_UnsuccessfulDeleteResult_ReturnFalse() {
+		// Arrange
+		Boolean success = false;
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.DeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(!isSuccess);
+	}
+
+	@IsTest
+	static void isSuccess_SuccessfulUndeleteResult_ReturnTrue() {
+		// Arrange
+		Boolean success = true;
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.UndeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(isSuccess);
+	}
+
+	@IsTest
+	static void isSuccess_UnsuccessfulUndeleteResult_ReturnFalse() {
+		// Arrange
+		Boolean success = false;
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":' + success + ',"id":""}', Database.UndeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+
+		// Act
+		Test.startTest();
+		Boolean isSuccess = dmlOperationResult.isSuccess();
+		Test.stopTest();
+
+		// Assert
+		System.assert(!isSuccess);
+	}
+
+	@IsTest
+	static void getErrors_SaveResultWithErrors_ReturnErrors() {
+		// Arrange
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{' +
+						'"success":false,' +
+						'"errors":[' +
+						'{' +
+						'"message":"You cannot do this...",' +
+						'"statusCode":"FIELD_CUSTOM_VALIDATION_EXCEPTION"' +
+						'}' +
+						']' +
+						'}',
+				Database.SaveResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+
+		// Act
+		Test.startTest();
+		List<Database.Error> actualErrors = dmlOperationResult.getErrors();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(saveResult.getErrors(), actualErrors);
+	}
+
+	@IsTest
+	static void getErrors_DeleteResultWithErrors_ReturnErrors() {
+		// Arrange
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{' +
+						'"success":false,' +
+						'"errors":[' +
+						'{' +
+						'"message":"You cannot do this...",' +
+						'"statusCode":"FIELD_CUSTOM_VALIDATION_EXCEPTION"' +
+						'}' +
+						']' +
+						'}',
+				Database.DeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+
+		// Act
+		Test.startTest();
+		List<Database.Error> actualErrors = dmlOperationResult.getErrors();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(deleteResult.getErrors(), actualErrors);
+	}
+
+	@IsTest
+	static void getErrors_UndeleteResultWithErrors_ReturnErrors() {
+		// Arrange
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{' +
+						'"success":false,' +
+						'"errors":[' +
+						'{' +
+						'"message":"You cannot do this...",' +
+						'"statusCode":"FIELD_CUSTOM_VALIDATION_EXCEPTION"' +
+						'}' +
+						']' +
+						'}',
+				Database.UndeleteResult.class);
+
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+
+		// Act
+		Test.startTest();
+		List<Database.Error> actualErrors = dmlOperationResult.getErrors();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(undeleteResult.getErrors(), actualErrors);
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_DmlOperationResultTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_DmlOperationResultTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_DmlOperationTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_DmlOperationTest.cls
@@ -1,0 +1,129 @@
+@IsTest
+private class fflib_DmlOperationTest {
+
+	@IsTest
+	static void constructor_Arguments_NewInstance() {
+		// Arrange
+		SObject account = new Account();
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				account,
+				fflib_DatabaseOperation.DATABASE_INSERT
+		);
+		Test.stopTest();
+
+		// Assert
+		System.assertNotEquals(null, dmlOperation);
+	}
+
+	@IsTest
+	static void constructor_NullSObject_ThrowException() {
+		// Arrange
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			new fflib_DmlOperation(null, fflib_DatabaseOperation.DATABASE_DELETE);
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof IllegalArgumentException);
+		System.assertEquals('Invalid SObject.', thrownException.getMessage());
+	}
+
+	@IsTest
+	static void getDatabaseOperation_DatabaseOperationIsSet_ReturnDatabaseOperation() {
+		// Arrange
+		fflib_DatabaseOperation databaseOperation = fflib_DatabaseOperation.DATABASE_INSERT;
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(new Account(), databaseOperation);
+
+		// Act
+		Test.startTest();
+		fflib_DatabaseOperation actualDatabaseOperation = dmlOperation.getDatabaseOperation();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(databaseOperation, actualDatabaseOperation);
+	}
+
+	@IsTest
+	static void getSObject_SObjectIsSet_ReturnSObject() {
+		// Arrange
+		SObject account = new Account();
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				account,
+				fflib_DatabaseOperation.DATABASE_INSERT
+		);
+
+		// Act
+		Test.startTest();
+		SObject actualSObject = dmlOperation.getSObject();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(account, actualSObject);
+	}
+
+	@IsTest
+	static void getOriginalSObject_SObject_ReturnOriginalSObject() {
+		// Arrange
+		SObject account = new Account(Name = 'test');
+		SObject originalAccount = account.clone();
+		fflib_DatabaseOperation databaseOperation = fflib_DatabaseOperation.DATABASE_INSERT;
+
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(account, databaseOperation);
+		account.put('Name', 'Changed');
+		dmlOperation.setOriginalSObject(originalAccount);
+
+		// Act
+		Test.startTest();
+		SObject actualSObjectToRollback = dmlOperation.getOriginalSObject();
+		Test.stopTest();
+
+		// Assert
+		System.assertNotEquals(account, actualSObjectToRollback);
+		System.assertEquals(originalAccount, actualSObjectToRollback);
+	}
+
+	@IsTest
+	static void getDmlOperationResult_DmlOperationResultIsSet_ReturnDmlOperationResult() {
+		// Arrange
+		fflib_ApexMocks mocks = new fflib_ApexMocks();
+		fflib_DmlOperationResult mockOperationResult =
+				(fflib_DmlOperationResult)mocks.mock(fflib_DmlOperationResult.class);
+
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(new Account(), fflib_DatabaseOperation.DATABASE_INSERT);
+		dmlOperation.setDmlOperationResult(mockOperationResult);
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperationResult actualDmlOperationResult = dmlOperation.getDmlOperationResult();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(mockOperationResult, actualDmlOperationResult);
+	}
+
+	@IsTest
+	static void getRollbackDmlOperation_DmlOperationIsSet_ReturnDmlOperation() {
+		// Arrange
+		fflib_DmlOperation rollbackDmlOperation = new fflib_DmlOperation(new Account(), null);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(new Account(), null);
+		dmlOperation.setRollbackDmlOperation(rollbackDmlOperation);
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation actualDmlOperation = dmlOperation.getRollbackDmlOperation();
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(rollbackDmlOperation, actualDmlOperation);
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_DmlOperationTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_DmlOperationTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -568,6 +568,22 @@ private with sharing class fflib_SObjectUnitOfWorkTest
         System.assertEquals(2, [SELECT COUNT() FROM Opportunity WHERE StageName = 'Closed']);
     }
 
+    @IsTest
+    static void testReset() {
+        Account newAccount = new Account(Name = 'test');
+
+        fflib_SObjectUnitOfWork unitOfWork =
+                new fflib_SObjectUnitOfWork(new List<SObjectType> {Account.getSObjectType()});
+        unitOfWork.registerNew(newAccount);
+
+        Test.startTest();
+        unitOfWork.reset();
+        unitOfWork.commitWork();
+        Test.stopTest();
+
+        System.assert([SELECT Id FROM Account].isEmpty());
+    }
+
     /**
      * Assert that actual events exactly match expected events (size, order and name)
      * and types match expected types

--- a/sfdx-source/apex-common/test/classes/fflib_UnitOfWorkPartialSuccessTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_UnitOfWorkPartialSuccessTest.cls
@@ -1,0 +1,1151 @@
+@IsTest
+private class fflib_UnitOfWorkPartialSuccessTest {
+
+	@IsTest
+	static void registerNew_SObject_ReturnDmlOperationWithSObject() {
+		// Arrange
+		SObject account = new Account(Name = 'test');
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation actualDmlOperation = unitOfWork.registerNewDmlOperation(account);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(account, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerNew_SObjectContainsId_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Account testAccount = new Account(Id = fflib_IDGenerator.generate(Account.getSObjectType()));
+
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerNewDmlOperation(testAccount);
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('Only new records can be registered as new.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void registerNew_SObjectNotOfRegisteredType_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Contact testContact = new Contact();
+
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerNewDmlOperation(testContact);
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('SObjectType Contact is not supported by this unit of work.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void commitWork_InvalidAccount_ReturnDmlOperationResult() {
+		// Arrange
+		List<Account> accounts = new List<Account>();
+		accounts.add(new Account());
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(
+				new List<SObjectType> {Account.getSObjectType()}
+		);
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerNewDmlOperations(accounts);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+
+		System.assertEquals(0, numAccounts);
+		System.assertEquals(1, dmlOperations.size());
+		System.assert(!dmlOperations[0].getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_MultipleSObjectTypes_ReturnDmlOperationResults() {
+		// Arrange
+		List<SObject> sobjects = new List<SObject>();
+		sobjects.add(new Contact(LastName = 'test'));
+		sobjects.add(new Account(Name = 'test'));
+
+		List<SObjectType> types = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getsObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(types);
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerNewDmlOperations(sobjects);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numInsertedAccounts = [SELECT COUNT() FROM Account];
+		Integer numInsertedContacts = [SELECT COUNT() FROM Contact];
+
+		System.assertEquals(1, numInsertedAccounts);
+		System.assertEquals(1, numInsertedContacts);
+		System.assertEquals(2, dmlOperations.size());
+		for (Integer i = 0; i < dmlOperations.size() - 1; i++) {
+			System.assert(sobjects.contains(dmlOperations[i].getSObject()));
+			System.debug(dmlOperations[i].getDmlOperationResult());
+			System.assert(dmlOperations[i].getDmlOperationResult().isSuccess());
+		}
+	}
+
+	@IsTest
+	static void commitWork_MultipleSObjectTypesInOppositeOrder_DmlOperationsContainCorrectResults() {
+		// Arrange
+		List<SObjectType> sObjectTypes = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getSObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(sObjectTypes);
+
+		Contact contact = new Contact(LastName = 'test');
+		fflib_DmlOperation contactDmlOperation = unitOfWork.registerNewDmlOperation(contact);
+		Account account = new Account(Name = 'test');
+		fflib_DmlOperation accountDmlOperation = unitOfWork.registerNewDmlOperation(account);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		System.assert(contactDmlOperation.getDmlOperationResult().isSuccess());
+		System.assertEquals(contact.Id, contactDmlOperation.getDmlOperationResult().getId());
+		System.assert(accountDmlOperation.getDmlOperationResult().isSuccess());
+		System.assertEquals(account.Id, accountDmlOperation.getDmlOperationResult().getId());
+	}
+
+	@IsTest
+	static void registerDirtyDmlOperation_SObject_ReturnUpdateDmlOperation() {
+		// Arrange
+		Account account = new Account(Name = 'test');
+		account.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation actualDmlOperation =
+				unitOfWork.registerDirtyDmlOperation(account);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_UPDATE,
+				actualDmlOperation.getDatabaseOperation());
+		System.assertEquals(account, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerDirtyDmlOperation_MultipleSObjects_ReturnMultipleUpdateDmlOperation() {
+		// Arrange
+		Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Account account = new Account(Id = accountId, Name = 'test');
+		Account account2 = new Account(Id = accountId, Name = 'test2');
+		List<SObject> sObjects = new List<SObject> {account, account2};
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		List<fflib_DmlOperation> actualDmlOperations =
+				unitOfWork.registerDirtyDmlOperations(sObjects);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(2, actualDmlOperations.size());
+		for (fflib_DmlOperation dmlOperation : actualDmlOperations) {
+			System.assert(sObjects.contains(dmlOperation.getSObject()));
+		}
+	}
+
+	@IsTest
+	static void registerDirtyDmlOperation_NewSObject_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerDirtyDmlOperation(new Account());
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('Only existing records can be registered as dirty.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void registerDirtyDmlOperation_SObjectUnsupportedType_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerDirtyDmlOperation(
+					new Contact(Id = fflib_IDGenerator.generate(Contact.getSObjectType()))
+			);
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('SObjectType Contact is not supported by this unit of work.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void commitWork_SObjectIsRegisteredDirty_SObjectIsUpdated() {
+		// Arrange
+		Account updateAccount = new Account(Name = 'test');
+		insert updateAccount;
+		updateAccount.Name = 'Changed';
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		fflib_DmlOperation dmlOperation = unitOfWork.registerDirtyDmlOperation(updateAccount);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> updatedAccounts = [SELECT Name FROM Account];
+
+		System.assertEquals(1, updatedAccounts.size());
+		System.assertEquals('Changed', updatedAccounts[0].Name);
+		System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_MultipleSObjectIsRegisteredDirty_SObjectIsUpdated() {
+		// Arrange
+		Account updateAccount = new Account(Name = 'test');
+		Account updateAccount2 = new Account(Name = 'test2');
+		List<SObject> sObjects = new List<SObject> {updateAccount, updateAccount2};
+		insert sObjects;
+
+		updateAccount.Name = 'Changed';
+		updateAccount2.Name = 'Changed2';
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerDirtyDmlOperations(sObjects);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> updatedAccounts = [SELECT Name FROM Account];
+
+		System.assertEquals(2, updatedAccounts.size());
+		for (Account updatedAccount : updatedAccounts) {
+			System.assert(updatedAccount.Name.contains('Changed'));
+		}
+		for (fflib_DmlOperation dmlOperation : dmlOperations) {
+			System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+		}
+	}
+
+	@IsTest
+	static void commitWork_UpdateSObjectRelationship_SObjectIsUpdated() {
+		// Arrange
+		Account updateAccount = new Account(Name = 'test');
+		Contact updateContact = new Contact(LastName = 'test');
+		List<SObject> sObjects = new List<SObject> {updateAccount, updateContact};
+		insert sObjects;
+
+		List<SObjectType> sObjectTypes = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getSObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(sObjectTypes);
+		fflib_DmlOperation dmlOperation =
+				unitOfWork.registerDirtyDmlOperation(updateContact, Contact.AccountId, updateAccount);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> insertedAccounts = [SELECT Id FROM Account];
+		List<Contact> updatedContacts = [SELECT AccountId FROM Contact];
+
+		System.assertEquals(1, updatedContacts.size());
+		System.assertEquals(1, insertedAccounts.size());
+		System.assertEquals(insertedAccounts[0].Id, updatedContacts[0].AccountId);
+		System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_InsertSObjectAndUpdateDifferentSObject_BothAreCommitted() {
+		// Arrange
+		List<SObjectType> sObjectTypes = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getSObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(sObjectTypes);
+
+		Account account = new Account(Name = 'test');
+		fflib_DmlOperation insertDmlOperation = unitOfWork.registerNewDmlOperation(account);
+		Contact contact = new Contact(LastName = 'test');
+		insert contact;
+		contact.LastName = 'Changed';
+		fflib_DmlOperation updateDmlOperation = unitOfWork.registerDirtyDmlOperation(contact);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> inserteAccounts = [SELECT Id FROM Account];
+		List<Contact> updatedContacts = [SELECT LastName FROM Contact];
+
+		System.assertEquals(1, inserteAccounts.size());
+		System.assertEquals(1, updatedContacts.size());
+		System.assertEquals('Changed', updatedContacts[0].LastName);
+		System.assert(insertDmlOperation.getDmlOperationResult().isSuccess());
+		System.assert(updateDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void reset_SObjectIsRegistered_NothingIsCommitted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		fflib_DmlOperation dmlOperation = unitOfWork.registerNewDmlOperation(newAccount);
+
+		// Act
+		Test.startTest();
+		unitOfWork.reset();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> insertedAccounts = [SELECT Id FROM Account];
+		System.assert(insertedAccounts.isEmpty());
+	}
+
+	@IsTest
+	static void commitWork_UnitOfWorkIsResetAndNewSOjectIsRegistered_SObjectIsInserted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		fflib_DmlOperation dmlOperation = unitOfWork.registerNewDmlOperation(newAccount);
+		unitOfWork.reset();
+
+		unitOfWork.registerNewDmlOperation(newAccount);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> insertedAccounts = [SELECT Id FROM Account];
+		System.assertEquals(1, insertedAccounts.size());
+	}
+
+	@IsTest
+	static void registerDeleteDmlOperation_SObjectToDelete_ReturnDeleteDmlOperation() {
+		// Arrange
+		Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Account existingAccount = new Account(Id = accountId);
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation dmlOperation = unitOfWork.registerDeleteDmlOperation(existingAccount);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_DELETE,
+				dmlOperation.getDatabaseOperation());
+	}
+
+	@IsTest
+	static void registerDeleteDmlOperations_MultipleSObjectToDelete_ReturnDeleteDmlOperations() {
+		// Arrange
+		Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Account existingAccount = new Account(Id = accountId);
+		Account existingAccount2 = new Account(Id = accountId);
+		List<Account> accounts = new List<Account> {existingAccount, existingAccount2};
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerDeleteDmlOperations(accounts);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(2, dmlOperations.size());
+		for (fflib_DmlOperation dmlOperation : dmlOperations) {
+			System.assertEquals(fflib_DatabaseOperation.DATABASE_DELETE,
+					dmlOperation.getDatabaseOperation());
+		}
+	}
+
+	@IsTest
+	static void registerDeleteDmlOperation_RecordWithoutId_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWorkPartialSuccess =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType>());
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWorkPartialSuccess.registerDeleteDmlOperation(new Account());
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('Only existing records can be registered for deletion.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void registerDeleteDmlOperation_UnregisteredSObjectType_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWorkPartialSuccess =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType>());
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+			unitOfWorkPartialSuccess.registerDeleteDmlOperation(new Account(Id = accountId));
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('SObjectType Account is not supported by this unit of work.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void commitWork_SObjectRegisteredToBeDeleted_SObjectIsDeleted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		insert newAccount;
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		fflib_DmlOperation dmlOperation = unitOfWork.registerDeleteDmlOperation(newAccount);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+
+		System.assertEquals(0, numAccounts);
+		System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_MultipleSObjectTypesRegisteredForDeletion_DmlOperationsContainCorrectResults() {
+		// Arrange
+		List<SObjectType> sObjectTypes = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getSObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(sObjectTypes);
+
+		Account account = new Account(Name = 'test');
+		Contact contact = new Contact(LastName = 'test');
+		insert new List<SObject> {account, contact};
+		fflib_DmlOperation accountDmlOperation = unitOfWork.registerDeleteDmlOperation(account);
+		fflib_DmlOperation contactDmlOperation = unitOfWork.registerDeleteDmlOperation(contact);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		System.assert(accountDmlOperation.getDmlOperationResult().isSuccess());
+		System.assert(String.isNotBlank(accountDmlOperation.getDmlOperationResult().getId()));
+		System.assertEquals(account.Id, accountDmlOperation.getDmlOperationResult().getId());
+		System.assert(contactDmlOperation.getDmlOperationResult().isSuccess());
+		System.assert(String.isNotBlank(contactDmlOperation.getDmlOperationResult().getId()));
+		System.assertEquals(contact.Id, contactDmlOperation.getDmlOperationResult().getId());
+	}
+
+	@IsTest
+	static void registerUndeleteDmlOperation_DeletedRecord_ReturnUndeleteDmlOperation() {
+		// Arrange
+		Account deletedAccount = new Account();
+		deletedAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		fflib_DmlOperation dmlOperation = unitOfWork.registerUndeleteDmlOperation(deletedAccount);
+		Test.stopTest();
+
+		// Assert
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_UNDELETE,
+				dmlOperation.getDatabaseOperation());
+		System.assertEquals(deletedAccount, dmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerUndeleteDmlOperation_MultipleDeletedRecords_ReturnUndeleteDmlOperations() {
+		// Arrange
+		Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+		Account deletedAccount = new Account(Id = accountId);
+		Account deletedAccount2 = new Account(Id = accountId);
+		List<SObject> sObjects = new List<SObject> {deletedAccount, deletedAccount2};
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerUndeleteDmlOperations(sObjects);
+		Test.stopTest();
+
+		// Assert
+		for (fflib_DmlOperation dmlOperation : dmlOperations) {
+			System.assertEquals(fflib_DatabaseOperation.DATABASE_UNDELETE,
+					dmlOperation.getDatabaseOperation());
+			System.assert(sObjects.contains(dmlOperation.getSObject()));
+		}
+	}
+
+	@IsTest
+	static void registerUndeleteDmlOperation_RecordWithoutAnId_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerUndeleteDmlOperation(new Account());
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('Only previously deleted records can be registered for undeletion.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void registerUndeleteDmlOperation_SObjectTypeNotRegistered_ThrowException() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType>());
+		Exception thrownException;
+
+		// Act
+		Test.startTest();
+		try {
+			Id accountId = fflib_IDGenerator.generate(Account.getSObjectType());
+			unitOfWork.registerUndeleteDmlOperation(new Account(Id = accountId));
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof fflib_SObjectUnitOfWork.UnitOfWorkException);
+		System.assertEquals('SObjectType Account is not supported by this unit of work.',
+				thrownException.getMessage());
+	}
+
+	@IsTest
+	static void commitWork_RegisterSObjectForUndeletion_SObjectIsUndeleted() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		Account account = new Account(Name = 'test');
+		insert account;
+		delete account;
+
+		fflib_DmlOperation dmlOperation = unitOfWork.registerUndeleteDmlOperation(account);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+
+		System.assertEquals(1, numAccounts);
+		System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_RegisterSObjectsForUndeletion_SObjectsAreUndeleted() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		Account account = new Account(Name = 'test');
+		Account account2 = new Account(Name = 'test2');
+		List<SObject> sObjects = new List<SObject> {account, account2};
+		insert sObjects;
+		delete sObjects;
+
+		List<fflib_DmlOperation> dmlOperations = unitOfWork.registerUndeleteDmlOperations(sObjects);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+
+		System.assertEquals(2, numAccounts);
+		for (fflib_DmlOperation dmlOperation : dmlOperations) {
+			System.assert(dmlOperation.getDmlOperationResult().isSuccess());
+		}
+	}
+
+	@IsTest
+	static void commitWork_MultipleRegisteredTypesAndSObjects_DmlOperationsContainCorrectResults() {
+		// Arrange
+		List<SObjectType> sObjectTypes = new List<SObjectType> {
+				Account.getSObjectType(),
+				Contact.getSObjectType(),
+				Opportunity.getSObjectType()
+		};
+		fflib_UnitOfWorkPartialSuccess unitOfWork = new fflib_UnitOfWorkPartialSuccess(sObjectTypes);
+
+		Integer numInvalidSObjects = 3;
+		Integer numSObjectsPerOperation = 9;
+
+		List<SObject> sObjectsToRegisterNew = new List<SObject>();
+		List<SObject> sObjectsToRegisterDirty = new List<SObject>();
+		List<SObject> sObjectsToRegisterDelete = new List<SObject>();
+		sObjectsToRegisterNew = createSObjectsToRegister(numSObjectsPerOperation);
+		sObjectsToRegisterNew.add(new Account());
+		sObjectsToRegisterDirty = createSObjectsToRegister(numSObjectsPerOperation);
+		sObjectsToRegisterDelete = createSObjectsToRegister(numSObjectsPerOperation);
+		List<SObject> allSObjectsToInsert = new List<SObject>();
+		insert sObjectsToRegisterDirty;
+		insert sObjectsToRegisterDelete;
+
+		List<fflib_DmlOperation> insertDmlOperations =
+				unitOfWork.registerNewDmlOperations(sObjectsToRegisterNew);
+		List<fflib_DmlOperation> deleteDmlOperations =
+				unitOfWork.registerDeleteDmlOperations(sObjectsToRegisterDelete);
+
+		for (Integer i = 0; i < sObjectsToRegisterDirty.size(); i++) {
+			SObject record = sObjectsToRegisterDirty[i];
+			if (record.getSObjectType() == Contact.getSObjectType()) {
+				record.put('LastName', 'Changed' + i);
+			} else {
+				record.put('Name', 'Changed' + i);
+			}
+		}
+		sObjectsToRegisterDirty[0].put('Name', '');
+		List<fflib_DmlOperation> updateDmlOperations =
+				unitOfWork.registerDirtyDmlOperations(sObjectsToRegisterDirty);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		for (Integer i; i < numSObjectsPerOperation; i++) {
+			fflib_DmlOperation insertDmlOperation = insertDmlOperations[i];
+			fflib_DmlOperation updateDmlOperation = updateDmlOperations[i];
+			fflib_DmlOperation deleteDmlOperation = deleteDmlOperations[i];
+
+			System.assert(insertDmlOperation.getDmlOperationResult().isSuccess());
+			System.assertEquals(sObjectsToRegisterNew[i].Id,
+					insertDmlOperation.getDmlOperationResult().getId());
+			System.assert(updateDmlOperation.getDmlOperationResult().isSuccess());
+			if (i != 0) {
+				System.assertEquals(sObjectsToRegisterDirty[i].Id,
+						updateDmlOperation.getDmlOperationResult().getId());
+				System.assert(deleteDmlOperation.getDmlOperationResult().isSuccess());
+				System.assertEquals(sObjectsToRegisterDelete[i].Id,
+						deleteDmlOperation.getDmlOperationResult().getId());
+			}
+		}
+		System.assert(!insertDmlOperations[numSObjectsPerOperation].getDmlOperationResult().isSuccess());
+		System.assert(!updateDmlOperations[0].getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void registerRollback_InsertDmlOperation_DeleteDmlOperationSet() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		newAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_INSERT
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation actualDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_DELETE,
+				actualDmlOperation.getDatabaseOperation());
+		System.assertEquals(newAccount, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerRollback_UpdateDmlOperation_UpdateDmlOperationWithOriginalSObjectSet() {
+		// Arrange
+		Account updateAccount = new Account(Name = 'test');
+		updateAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+		Account originalAccount = updateAccount.clone(true);
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + updateAccount.Id + '"}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				updateAccount,
+				fflib_DatabaseOperation.DATABASE_UPDATE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		dmlOperation.setOriginalSObject(originalAccount);
+		updateAccount.Name = 'Changed';
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation actualDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_UPDATE,
+				actualDmlOperation.getDatabaseOperation());
+		System.assertEquals(originalAccount, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerRollback_DeleteDmlOperation_UndeleteDmlOperationSet() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		newAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.DeleteResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_DELETE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation actualDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_UNDELETE,
+				actualDmlOperation.getDatabaseOperation());
+		System.assertEquals(newAccount, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerRollback_UndeleteDmlOperation_DeleteDmlOperationSet() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		newAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.UndeleteResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_UNDELETE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation actualDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(fflib_DatabaseOperation.DATABASE_DELETE,
+				actualDmlOperation.getDatabaseOperation());
+		System.assertEquals(newAccount, actualDmlOperation.getSObject());
+	}
+
+	@IsTest
+	static void registerRollback_Null_ThrowException() {
+		// Arrange
+		Exception thrownException;
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType>());
+
+		// Act
+		Test.startTest();
+		try {
+			unitOfWork.registerRollback(null);
+		} catch (Exception e) {
+			thrownException = e;
+		}
+		Test.stopTest();
+
+		// Assert
+		System.assert(thrownException instanceof IllegalArgumentException);
+		System.assertEquals('Invalid DML operation.', thrownException.getMessage());
+	}
+
+	@IsTest
+	static void registerRollback_DmlOperationWithoutResult_RollbackDmlOperationNotSet() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Account invalidAccount = new Account();
+
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(invalidAccount, fflib_DatabaseOperation.DATABASE_INSERT);
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(null, rollbackDmlOperation);
+	}
+
+	@IsTest
+	static void registerRollback_DmlOperationWithUnsuccessfulResullt_RollbackDmlOperationNotSet() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		Account invalidAccount = new Account();
+
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":false,"id":""}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(invalidAccount, fflib_DatabaseOperation.DATABASE_INSERT);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		Test.stopTest();
+
+		// Assert
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(null, rollbackDmlOperation);
+	}
+
+	@IsTest
+	static void registerRollbacks_MultipleDmlOperations_RollbackDmlOperationsSet() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		newAccount.Id = fflib_IDGenerator.generate(Account.getSObjectType());
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation =
+				new fflib_DmlOperation(newAccount, fflib_DatabaseOperation.DATABASE_INSERT);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		fflib_DmlOperation dmlOperation2 =
+				new fflib_DmlOperation(newAccount, fflib_DatabaseOperation.DATABASE_INSERT);
+		dmlOperation2.setDmlOperationResult(dmlOperationResult);
+		List<fflib_DmlOperation> dmlOperations =
+				new List<fflib_DmlOperation> {dmlOperation, dmlOperation2};
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollbacks(dmlOperations);
+		Test.stopTest();
+
+		// Assert
+		List<fflib_DmlOperation> actualDmlOperations = new List<fflib_DmlOperation>();
+		for (fflib_DmlOperation existingDmlOperation : dmlOperations) {
+			actualDmlOperations.add(existingDmlOperation.getRollbackDmlOperation());
+		}
+
+		System.assertEquals(2, actualDmlOperations.size());
+		for (fflib_DmlOperation actualDmlOperation : actualDmlOperations) {
+			System.assertEquals(fflib_DatabaseOperation.DATABASE_DELETE,
+					actualDmlOperation.getDatabaseOperation());
+		}
+	}
+
+	@IsTest
+	static void commitWork_InsertRollbackRegistered_SObjectIsDeleted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_INSERT
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		insert newAccount;
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		unitOfWork.registerRollback(dmlOperation);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(0, numAccounts);
+		System.assert(rollbackDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_UpdateRollbackRegistered_SObjectIsUpdatedToOriginal() {
+		// Arrange
+		Account originalAccount = new Account(Name = 'test');
+		insert originalAccount;
+		Account updateAccount = originalAccount.clone(true);
+
+		Database.SaveResult saveResult = (Database.SaveResult)JSON.deserialize(
+				'{"success":true,"id":"' + originalAccount.Id + '"}', Database.SaveResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(saveResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				updateAccount,
+				fflib_DatabaseOperation.DATABASE_UPDATE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		dmlOperation.setOriginalSObject(originalAccount);
+
+		updateAccount.Name = 'Changed';
+		update updateAccount;
+		Account existingAccountInDatabase = [SELECT Name FROM Account WHERE Id = :originalAccount.Id];
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		unitOfWork.registerRollback(dmlOperation);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		List<Account> updatedAccounts = [SELECT Name FROM Account];
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+
+		System.assertEquals(1, updatedAccounts.size());
+		System.assertEquals('Changed', existingAccountInDatabase.Name);
+		System.assertEquals('test', updatedAccounts[0].Name);
+		System.assert(rollbackDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_DeleteRollbackRegistered_SObjectIsUndeleted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		insert newAccount;
+		Database.DeleteResult deleteResult = (Database.DeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.DeleteResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(deleteResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_DELETE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		delete newAccount;
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		unitOfWork.registerRollback(dmlOperation);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(1, numAccounts);
+		System.assert(rollbackDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_UndeleteRollbackRegistered_SObjectIsDeleted() {
+		// Arrange
+		Account newAccount = new Account(Name = 'test');
+		insert newAccount;
+		Database.UndeleteResult undeleteResult = (Database.UndeleteResult)JSON.deserialize(
+				'{"success":true,"id":"' + newAccount.Id + '"}', Database.UndeleteResult.class);
+		fflib_DmlOperationResult dmlOperationResult = new fflib_DmlOperationResult(undeleteResult);
+		fflib_DmlOperation dmlOperation = new fflib_DmlOperation(
+				newAccount,
+				fflib_DatabaseOperation.DATABASE_UNDELETE
+		);
+		dmlOperation.setDmlOperationResult(dmlOperationResult);
+		delete newAccount;
+		undelete newAccount;
+
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+		unitOfWork.registerRollback(dmlOperation);
+
+		// Act
+		Test.startTest();
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+		System.assertEquals(0, numAccounts);
+		System.assert(rollbackDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	@IsTest
+	static void commitWork_InsertedDmlOperationRolledBack_SObjectIsDeleted() {
+		// Arrange
+		fflib_UnitOfWorkPartialSuccess unitOfWork =
+				new fflib_UnitOfWorkPartialSuccess(new List<SObjectType> {Account.getSObjectType()});
+
+		Account newAccount = new Account(Name = 'test');
+		fflib_DmlOperation dmlOperation = unitOfWork.registerNewDmlOperation(newAccount);
+		unitOfWork.commitWork();
+
+		// Act
+		Test.startTest();
+		unitOfWork.registerRollback(dmlOperation);
+		unitOfWork.commitWork();
+		Test.stopTest();
+
+		// Assert
+		Integer numAccounts = [SELECT COUNT() FROM Account];
+		fflib_DmlOperation rollbackDmlOperation = dmlOperation.getRollbackDmlOperation();
+
+		System.assertEquals(0, numAccounts);
+		System.assert(rollbackDmlOperation.getDmlOperationResult().isSuccess());
+	}
+
+	static List<SObject> createSObjectsToRegister(Integer numSObjectsPerOperation) {
+		List<SObject> sObjects = new List<SObject>();
+		for (Integer i = 0; i < numSObjectsPerOperation; i++) {
+			if (Math.mod(i, 3) == 0) {
+				sObjects.add(new Account(Name = 'test' + i));
+			}
+			if (Math.mod(i, 3) == 1) {
+				sObjects.add(new Contact(LastName = 'test' + i));
+			}
+			if (Math.mod(i, 3) == 2) {
+				Opportunity opp = new Opportunity();
+				opp.CloseDate = System.today();
+				opp.StageName = '1. Open';
+				opp.Name = 'test' + i;
+				sObjects.add(opp);
+			}
+		}
+		return sObjects;
+	}
+}

--- a/sfdx-source/apex-common/test/classes/fflib_UnitOfWorkPartialSuccessTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/classes/fflib_UnitOfWorkPartialSuccessTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Hey all,

I've added to the unit of work class to allow for a few new things:
* Ability to allow for partial successes when committing work
* Ability to register undelete operations
* DML classes to track the results of DML operations on registered records
* Ability to rollback those DML operations
* Ability to reset the unit of work instantiation for re-use after committing work (is used for rollbacks on same unit of work object)

## Usage

You use this class similarly to SObjectUnitOfWork. The following example all have a bulkified version of their methods as well.

If you want to register a new record to be inserted,
```apex
fflib_DmlOperation dmlOperation = unitOfWork.registerNewDmlOperation(record);
```

if you want to register a record to be updated,
```apex
fflib_DmlOperation dmlOperation = unitOfWork.registerDirtyDmlOperation(record);
```

If you want to register a record to be deleted,
```apex
fflib_DmlOperation dmlOperation = unitOfWork.registerDeleteDmlOperation(record);
```

If you want to register a record to be undeleted,
```apex
fflib_DmlOperation dmlOperation = unitOfWork.registerUndeleteDmlOperation(record);
```

The DmlOperation objects will update by reference once `commitWork` is called. You can retrieve their information by the fflib_DmlOperationResult objects associated with them. the fflib_DmlOperationResult class utilizes a similar API to the SaveResult classes of apex.

For checking if the DML Operation was a success,
```apex
fflib_DmlOperationResult dmlOperationResult = dmlOperation.getDmlOperationResult();
Boolean isSuccess = dmlOperationResult.isSuccess();
```

The rollback operations require a DmlOperation object in order to rollback the operation. It logically does the opposite DML Operation of whatever it was given. So if an insert DML Operation is given to it, it will register a new delete DML Operation with the unit of work instantiation.

Rolling back insert operation -> registers delete operation
Rolling back update operation -> registers update operation with original record
Rolling back delete operation -> registers undelete operation
Rolling back undelete operation -> registers delete operation

Another thing to note is that the unit of work instantiation will be reset once it commits work. This allows for re-use or the rolling back of records without having to instantiate a new object.

For rolling back an insert operation,
```apex
fflib_DmlOperation insertDmlOperation = unitOfWork.registerNew(record);
unitOfWork.commitWork();

fflib_DmlOperation rollbackOperation = unitOfWork.registerRollback(insertDmlOperation);
unitOfWork.commitWork();
```

## Considerations
When using rollback operations, please keep in mind DML Salesforce limits. Rolling back operations will, of course, double the amount of operations that the original registering of work commits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/319)
<!-- Reviewable:end -->
