### PR TITLE
Application Class Extensibility

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -230,7 +230,7 @@ public virtual class fflib_Application
 		 * @param recordIds The SObject record Ids, must be all the same SObjectType
 		 * @exception Is thrown if the record Ids are not all the same or the SObjectType is not registered
 		 **/
-		public List<SObject> selectById(Set<Id> recordIds)
+		public virtual List<SObject> selectById(Set<Id> recordIds)
 		{
 			// No point creating an empty Domain class, nor can we determine the SObjectType anyway
 			if(recordIds==null || recordIds.size()==0)
@@ -258,7 +258,7 @@ public virtual class fflib_Application
 		 * @param relatedRecords used to extract the related record Ids, e.g. Opportunity records
 		 * @param relationshipField field in the passed records that contains the relationship records to query, e.g. Opportunity.AccountId
 		 **/
-		public List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField)
+		public virtual List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField)
 		{
 			Set<Id> relatedIds = new Set<Id>();
 			for(SObject relatedRecord : relatedRecords)
@@ -287,6 +287,11 @@ public virtual class fflib_Application
 		protected Map<Object, Type> constructorTypeByObject;
 
 		protected Map<Object, fflib_IDomain> mockDomainByObject;
+
+        /**
+		 * Constructs a Domain factory
+		 **/
+		public DomainFactory() { }
 
 		/**
 		 * Constructs a Domain factory, using an instance of the Selector Factory
@@ -408,18 +413,18 @@ public virtual class fflib_Application
 		}
 
 		@TestVisible
-		private virtual void setMock(fflib_ISObjectDomain mockDomain)
+		protected virtual void setMock(fflib_ISObjectDomain mockDomain)
 		{
 			mockDomainByObject.put((Object) mockDomain.sObjectType(), (fflib_IDomain) mockDomain);
 		}
 
 		@TestVisible
-		private virtual void setMock(fflib_IDomain mockDomain)
+		protected virtual void setMock(fflib_IDomain mockDomain)
 		{
 			mockDomainByObject.put(mockDomain.getType(), mockDomain);
 		}
 
-		private Map<Object, Type> getConstructorTypeByObject(Map<SObjectType, Type> constructorTypeBySObjectType)
+		protected virtual Map<Object, Type> getConstructorTypeByObject(Map<SObjectType, Type> constructorTypeBySObjectType)
 		{
 			Map<Object, Type> result = new Map<Object, Type>();
 			for (SObjectType sObjectType : constructorTypeBySObjectType.keySet())

--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -41,6 +41,11 @@ public virtual class fflib_Application
 
 		/**
 		 * Constructs a Unit Of Work factory
+		 **/
+		public UnitOfWorkFactory() { }
+
+		/**
+		 * Constructs a Unit Of Work factory
 		 *
 		 * @param objectTypes List of SObjectTypes in dependency order
 		 **/
@@ -54,7 +59,7 @@ public virtual class fflib_Application
 		 *   SObjectType list provided in the constructor, returns a Mock implementation
 		 *   if set via the setMock method
 		 **/
-		public fflib_ISObjectUnitOfWork newInstance()
+		public virtual fflib_ISObjectUnitOfWork newInstance()
 		{
 			// Mock?
 			if(m_mockUow!=null)
@@ -62,20 +67,18 @@ public virtual class fflib_Application
 			return new fflib_SObjectUnitOfWork(m_objectTypes);
 		}
 
-
 		/**
 		 * Returns a new fflib_SObjectUnitOfWork configured with the
 		 *   SObjectType list provided in the constructor, returns a Mock implementation
 		 *   if set via the setMock method
 		 **/
-		public fflib_ISObjectUnitOfWork newInstance(fflib_SObjectUnitOfWork.IDML dml)
+		public virtual fflib_ISObjectUnitOfWork newInstance(fflib_SObjectUnitOfWork.IDML dml)
 		{
 			// Mock?
 			if(m_mockUow!=null)
 				return m_mockUow;
 			return new fflib_SObjectUnitOfWork(m_objectTypes, dml);
 		}
-
 
 		/**
 		 * Returns a new fflib_SObjectUnitOfWork configured with the
@@ -85,7 +88,7 @@ public virtual class fflib_Application
 		 * @remark If mock is set, the list of SObjectType in the mock could be different
 		 *         then the list of SObjectType specified in this method call
 		 **/
-		public fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes)
+		public virtual fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes)
 		{
 			// Mock?
 			if(m_mockUow!=null)
@@ -101,7 +104,7 @@ public virtual class fflib_Application
 		 * @remark If mock is set, the list of SObjectType in the mock could be different
 		 *         then the list of SObjectType specified in this method call
 		 **/
-		public fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes, fflib_SObjectUnitOfWork.IDML dml)
+		public virtual fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes, fflib_SObjectUnitOfWork.IDML dml)
 		{
 			// Mock?
 			if(m_mockUow!=null)
@@ -109,9 +112,8 @@ public virtual class fflib_Application
 			return new fflib_SObjectUnitOfWork(objectTypes, dml);
 		}
 
-
 		@TestVisible
-		private void setMock(fflib_ISObjectUnitOfWork mockUow)
+		protected virtual void setMock(fflib_ISObjectUnitOfWork mockUow)
 		{
 			m_mockUow = mockUow;
 		}
@@ -125,6 +127,11 @@ public virtual class fflib_Application
 		protected Map<Type, Type> m_serviceInterfaceTypeByServiceImplType;
 
 		protected Map<Type, Object> m_serviceInterfaceTypeByMockService;
+
+		/**
+		 * Constructs a simple Service Factory
+		 **/
+		public ServiceFactory() { }
 
 		/**
 		 * Constructs a simple Service Factory, 
@@ -162,7 +169,7 @@ public virtual class fflib_Application
 		}
 
 		@TestVisible
-		private virtual void setMock(Type serviceInterfaceType, Object serviceImpl)
+		protected virtual void setMock(Type serviceInterfaceType, Object serviceImpl)
 		{
 			m_serviceInterfaceTypeByMockService.put(serviceInterfaceType, serviceImpl);
 		}
@@ -175,6 +182,11 @@ public virtual class fflib_Application
 	{
 		protected Map<SObjectType, Type> m_sObjectBySelectorType;
 		protected Map<SObjectType, fflib_ISObjectSelector> m_sObjectByMockSelector;
+
+		/**
+		 * Constructs a simple Selector Factory
+		 **/
+		public SelectorFactory() { }
 
 		/**
 		 * Consturcts a Selector Factory linking SObjectType's with Apex Classes implement the fflib_ISObjectSelector interface
@@ -259,7 +271,7 @@ public virtual class fflib_Application
 		}
 
 		@TestVisible
-		private virtual void setMock(fflib_ISObjectSelector selectorInstance)
+		protected virtual void setMock(fflib_ISObjectSelector selectorInstance)
 		{
 			m_sObjectByMockSelector.put(selectorInstance.sObjectType(), selectorInstance);
 		} 


### PR DESCRIPTION
As previously mentioned in #257 there was a request to be able to extend the fflib_Application class for use cases such as implementing force-di. Frameworks such as AT4DX have already done this, however, they implement a surrogate copy of the fflib_Application class, which is not DRY.

The AT4DX project had an [open issue](https://github.com/apex-enterprise-patterns/at4dx/issues/28) to extend the fflib_Application class from the work done in #257, but it was quickly discovered there were issues still present. Mainly, AT4DX needs 0-arg constructors in the fflib_Application class, and the ability to override the behavior of the setMock methods.

This PR adds 0-arg constructors to the fflib_Application class, as well as marking the setMock methods as protected so that they can be overriden. I have also added the virtual modifier to some of the other methods that were not originally marked as virtual.

For additional discussion on the need for the 0-arg constructors, see the following discussion on [Stackexchange](https://salesforce.stackexchange.com/questions/24275/inheriting-non-implicit-constructors-on-apex-classes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/334)
<!-- Reviewable:end -->
