### PR TITLE
Change buildQuerySObjectById access modifier to protected

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -429,7 +429,7 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Constructs the default SOQL query for this selector, see selectSObjectsById and queryLocatorById
      **/    
-    private String buildQuerySObjectById()
+    protected String buildQuerySObjectById()
     {   
         return newQueryFactory().setCondition('id in :idSet').toSOQL();
     }


### PR DESCRIPTION
Change buildQuerySObjectById() access modifier to protected to allow override of 'with sharing' for selectSObjectsById() and queryLocatorById(). See #199 and #262 for more details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/339)
<!-- Reviewable:end -->
