### PR TITLE
Change private vars into protected for UnitOfWorkFactory

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -36,8 +36,8 @@ public virtual class fflib_Application
 	 **/
 	public virtual class UnitOfWorkFactory
 	{
-		private List<SObjectType> m_objectTypes;
-		private fflib_ISObjectUnitOfWork m_mockUow;
+		protected List<SObjectType> m_objectTypes;
+		protected fflib_ISObjectUnitOfWork m_mockUow;
 
 		/**
 		 * Constructs a Unit Of Work factory


### PR DESCRIPTION
It doesn't really make sense to have a virtual factory class an not being able to access its ObjectTypes list in the extended class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/352)
<!-- Reviewable:end -->
