### PR TITLE
Add method overloads for getChangedRecords

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
@@ -284,6 +284,15 @@ public virtual with sharing class fflib_SObjectDomain
     }
 
 	/**
+	 * Detects whether any values in context records have changed for given field as string
+	 * Returns list of SObject records that have changes in the specified field
+	 **/
+	public List<SObject> getChangedRecords(String fieldName)
+	{
+		return getChangedRecords(new Set<String>{ fieldName });
+	}
+
+	/**
 	 * Detects whether any values in context records have changed for given fields as strings
 	 * Returns list of SObject records that have changes in the specified fields
 	 **/
@@ -309,6 +318,15 @@ public virtual with sharing class fflib_SObjectDomain
 			}
 		}
 		return changedRecords;
+	}
+
+	/**
+	 * Detects whether any values in context records have changed for given field as token
+	 * Returns list of SObject records that have changes in the specified field
+	 **/
+	public List<SObject> getChangedRecords(Schema.SObjectField fieldToken)
+	{
+		return getChangedRecords(new Set<Schema.SObjectField>{ fieldToken });
 	}
 
 	/**


### PR DESCRIPTION
It is often that we only need to listen to one field that has been changed.
These method overloads avoid to have to build a Set<String> or Set<Schema.SObjectField> prior to invoking the original method.

This changes something like:
```
List<SObject> changedRecords = getChangedRecords(
				new Set<Schema.SObjectField>
				{
						CustomObject_c.RecordTypeId
				}
		);
```
into:
```
List<SObject> changedRecords = getChangedRecords( CustomObject_c.RecordTypeId );
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/360)
<!-- Reviewable:end -->
