### PR TITLE
Convert key search to lower case

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
@@ -77,7 +77,7 @@ public class fflib_SObjectDescribe {
 	private fflib_SObjectDescribe(Schema.SObjectType token){	
 		if(token == null)
 			throw new InvalidDescribeException('Invalid SObject type: null');
-		if(instanceCache.containsKey( String.valueOf(token) ))
+		if(instanceCache.containsKey( String.valueOf(token).toLowerCase() ))
 			throw new DuplicateDescribeException(token + ' is already in the describe cache');
 		this.token = token;
 		instanceCache.put( String.valueOf(token).toLowerCase() , this);

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
@@ -77,8 +77,6 @@ public class fflib_SObjectDescribe {
 	private fflib_SObjectDescribe(Schema.SObjectType token){	
 		if(token == null)
 			throw new InvalidDescribeException('Invalid SObject type: null');
-		if(instanceCache.containsKey( String.valueOf(token).toLowerCase() ))
-			throw new DuplicateDescribeException(token + ' is already in the describe cache');
 		this.token = token;
 		instanceCache.put( String.valueOf(token).toLowerCase() , this);
 	}


### PR DESCRIPTION
As far as I can tell, the check for the key being in the instance cache will never be executed. You're creating `fflib_SObjectDescribe` instances in three places:

- `fflib_SObjectDescribe.getDescribe(String)` (line 193)
- `fflib_SObjectDescribe.getDescribe(Schema.SObjectType)` (line 202)
- `fflib_SObjectDescribe.getDescribe(Schema.DescribeSObjectResult)` (line 210)

Each time you're only doing so after you've checked if the token (lower cased) is in the instance cache and only create the new instance if it's not.

But maybe you're directly instantiating this class in other places. If not, the check (and the exception) can be removed. If so, then this check should have the token converted to lower case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/364)
<!-- Reviewable:end -->
