### PR TITLE
Created fflib_WhereBuilder as a helper for fflib_QueryFactory

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_IWhereBuilder.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IWhereBuilder.cls
@@ -1,0 +1,6 @@
+public interface fflib_IWhereBuilder {
+    fflib_IWhereBuilder andX(String condition);
+    fflib_IWhereBuilder andX(fflib_IWhereBuilder condition);
+    fflib_IWhereBuilder orX(String condition);
+    fflib_IWhereBuilder orX(fflib_IWhereBuilder condition);
+}

--- a/sfdx-source/apex-common/main/classes/fflib_IWhereBuilder.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_IWhereBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/main/classes/fflib_WhereBuilder.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_WhereBuilder.cls
@@ -1,0 +1,77 @@
+public class fflib_WhereBuilder implements fflib_IWhereBuilder{
+    @testVisible
+    private List<Object> contents = new List<Object>();
+    public static fflib_IWhereBuilder whereX(String condition){
+        return new fflib_WhereBuilder(condition);
+    }
+    public static fflib_IWhereBuilder whereX(fflib_IWhereBuilder condition){
+        return new fflib_WhereBuilder(condition);
+    }
+    public static fflib_IWhereBuilder andX(String condition1, String condition2){
+        return new fflib_WhereBuilder(condition1).andX(condition2);
+    }
+    public static fflib_IWhereBuilder andX(String condition1, fflib_IWhereBuilder condition2){
+        return new fflib_WhereBuilder(condition1).andX(condition2);
+    }
+    public static fflib_IWhereBuilder andX(fflib_IWhereBuilder condition1, fflib_IWhereBuilder condition2){
+        return new fflib_WhereBuilder(condition1).andX(condition2);
+    }
+    public static fflib_IWhereBuilder orX(fflib_IWhereBuilder condition1, fflib_IWhereBuilder condition2){
+        return new fflib_WhereBuilder(condition1).orX(condition2);
+    }
+    public static fflib_IWhereBuilder orX(String condition1, String condition2){
+        return new fflib_WhereBuilder(condition1).orX(condition2);
+    }
+    public static fflib_IWhereBuilder orX(String condition1, fflib_IWhereBuilder condition2){
+        return new fflib_WhereBuilder(condition1).orX(condition2);
+    }
+    @testVisible
+    private fflib_WhereBuilder(){}
+    @testVisible
+    private fflib_WhereBuilder(String condition){
+        contents.add(condition);
+    }
+    @testVisible
+    private fflib_WhereBuilder(fflib_IWhereBuilder condition){
+        contents.add(condition);
+    }
+    public fflib_IWhereBuilder andX(String condition){
+        return this.addImpl('AND', condition);
+    }
+    public fflib_IWhereBuilder andX(fflib_IWhereBuilder condition){
+        return this.addImpl('AND', condition);
+    }
+    public fflib_IWhereBuilder orX(String condition){
+        return this.addImpl('OR', condition);
+    }
+    public fflib_IWhereBuilder orX(fflib_IWhereBuilder condition){
+        return this.addImpl('OR', condition);
+    }
+    override public String toString(){
+        if(contents.isEmpty()){
+            return null;
+        }
+        fflib_StringBuilder.CommaDelimitedListBuilder stringBuilder = new fflib_StringBuilder.CommaDelimitedListBuilder();
+        for(Object content : contents){
+            stringBuilder.add(formatContent(content));
+        }
+        stringBuilder.setDelimiter(' ');
+        return stringBuilder.toString();
+    }
+    @testVisible
+    private fflib_IWhereBuilder addImpl(String op, Object condition){
+        if(!contents.isEmpty()){
+            contents.add(op);
+        }
+        contents.add(condition);
+        return this;
+    }
+    @testVisible
+    private String formatContent(Object content){
+        String formatted = content.toString();
+        if(content instanceof fflib_IWhereBuilder){
+            formatted = '(' + formatted + ')';
+        }
+        return formatted;
+    }
+}

--- a/sfdx-source/apex-common/main/classes/fflib_WhereBuilder.cls-meta.xml
+++ b/sfdx-source/apex-common/main/classes/fflib_WhereBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/sfdx-source/apex-common/test/fflib_WhereBuilderTest.cls
+++ b/sfdx-source/apex-common/test/fflib_WhereBuilderTest.cls
@@ -1,0 +1,133 @@
+@isTest
+private class fflib_WhereBuilderTest{
+    @isTest
+    private static void staticWhereXString(){
+        String testParam = getRandomString();
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.whereX(testParam);
+        System.assertEquals(new List<Object>{testParam}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticWhereXBuilder(){
+        fflib_IWhereBuilder testParam = new fflib_WhereBuilder(getRandomString());
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.whereX(testParam);
+        System.assertEquals(new List<Object>{testParam}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticAndXStrings(){
+        String testParam1 = getRandomString();
+        String testParam2 = getRandomString();
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.andX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'AND', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticAndXBuilders(){
+        fflib_IWhereBuilder testParam1 = new fflib_WhereBuilder(getRandomString());
+        fflib_IWhereBuilder testParam2 = new fflib_WhereBuilder(getRandomString());
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.andX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'AND', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticAndXMix(){
+        String testParam1 = getRandomString();
+        fflib_IWhereBuilder testParam2 = new fflib_WhereBuilder(getRandomString());
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.andX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'AND', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticOrXStrings(){
+        String testParam1 = getRandomString();
+        String testParam2 = getRandomString();
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.orX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'OR', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticOrXBuilders(){
+        fflib_IWhereBuilder testParam1 = new fflib_WhereBuilder(getRandomString());
+        fflib_IWhereBuilder testParam2 = new fflib_WhereBuilder(getRandomString());
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.orX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'OR', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void staticOrXMix(){
+        String testParam1 = getRandomString();
+        fflib_IWhereBuilder testParam2 = new fflib_WhereBuilder(getRandomString());
+        fflib_WhereBuilder builder = (fflib_WhereBuilder) fflib_WhereBuilder.orX(testParam1, testParam2);
+        System.assertEquals(new List<Object>{testParam1, 'OR', testParam2}, builder.contents, 'Method call intialized builder incorrectly.');
+    }
+    @isTest
+    private static void ctor(){
+        System.assertEquals(0, new fflib_WhereBuilder().contents.size());
+    }
+    @isTest
+    private static void ctorString(){
+        String rando = getRandomString();
+        fflib_WhereBuilder builder = new fflib_WhereBuilder(rando);
+        System.assertEquals(new List<Object>{rando}, builder.contents, 'Constructor initialized contents incorrectly.');
+    }
+    @isTest
+    private static void ctorSubBuilder(){
+        fflib_WhereBuilder subBuilder = new fflib_WhereBuilder();
+        fflib_WhereBuilder builder = new fflib_WhereBuilder(subBuilder);
+        System.assertEquals(new List<Object>{subBuilder}, builder.contents, 'Constructor initialized contents incorrectly.');
+    }
+    @isTest
+    private static void andX(){
+        fflib_WhereBuilder builder = new fflib_WhereBuilder();
+        List<String> expected = new List<String>();
+        for(Integer i = 0; i < 42; i++){
+            String rando = getRandomString();
+            expected.add('AND');
+            expected.add(rando);
+            builder.andX(rando);
+        }
+        expected.remove(0);
+        System.assertEquals(expected, builder.contents, 'Contents of WhereBuilder were not as expected.');
+        System.assertEquals(String.join(expected, ' '), builder.toString());
+    }
+    @isTest
+    private static void orX(){
+        fflib_WhereBuilder builder = new fflib_WhereBuilder();
+        List<String> expected = new List<String>();
+        for(Integer i = 0; i < 42; i++){
+            String rando = getRandomString();
+            expected.add('OR');
+            expected.add(rando);
+            builder.orX(rando);
+        }
+        expected.remove(0);
+        System.assertEquals(expected, builder.contents, 'Contents of WhereBuilder were not as expected.');
+        System.assertEquals(String.join(expected, ' '), builder.toString(), 'WhereBuilder did not build a correct string.');
+    }
+    @isTest
+    private static void addImplEmpty(){
+        String expected = getRandomString();
+        fflib_WhereBuilder builder = new fflib_WhereBuilder();
+        builder.addImpl(getRandomString(), expected);
+        System.assertEquals(1, builder.contents.size(), 'Contents of WhereBuilder is not just the string added.');
+        System.assertEquals(expected, builder.contents[0], 'Contents of WhereBuilder were not as expected.');
+        System.assertEquals(expected, builder.toString(), 'WhereBuilder did not build a correct string.');
+    }
+    @isTest
+    private static void addImplNotEmpty(){
+        List<String> expected = new List<String>{getRandomString(), getRandomString(), getRandomString()};
+        fflib_WhereBuilder builder = new fflib_WhereBuilder(expected[0]);
+        String rando2 = getRandomString();
+        builder.addImpl(expected[1], expected[2]);
+        System.assertEquals(expected.size(), builder.contents.size(), 'Number of contents of WhereBuilder is not expected.');
+        System.assertEquals(expected, builder.contents, 'Contents of WhereBuilder were not as expected.');
+        System.assertEquals(String.join(expected, ' '), builder.toString(), 'WhereBuilder did not build a correct string.');
+    }
+    @isTest
+    private static void formatContentString(){
+        String testParam = getRandomString();
+        System.assertEquals(testParam, (new fflib_WhereBuilder()).formatContent(testParam), 'formatContent did not return the unchanged string.');
+    }
+    @isTest
+    private static void formatContentBuilder(){
+        fflib_IWhereBuilder testParam = new fflib_WhereBuilder(getRandomString());
+        System.assertEquals('(' + testParam.toString() + ')', (new fflib_WhereBuilder()).formatContent(testParam), 'formatContent did not return the unchanged string.');
+    }
+    private static String getRandomString(){
+        return 'Test' + Math.random().format();
+    }
+}

--- a/sfdx-source/apex-common/test/fflib_WhereBuilderTest.cls-meta.xml
+++ b/sfdx-source/apex-common/test/fflib_WhereBuilderTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>52.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
A simple class to avoid (part of) String concatenation. `setCondition`.

  1. Greater confidence with the compiler - Just like QueryFactory, this is compiled, which means even less of a chance for joining strings improperly.
  2. Easier testing - Instead of "expect the query to be this EXACT thing" (when order of things doesn't always matter) whereas now we can say "Assert that the WhereBuilder contains this exact set of criteria.
  3. Nested criteria - Huge benefit in my opinion to be have the _compiter_ match paren.
  4. Presumably, performance - Granted, you'd get similar with a fflib_StringBuilder, but still, it's worth noting that avoiding raw string concatenation is groovy.
  5. Readability - Check the examples below.

```
fflib_QueryFactory queryFactory = newQueryFactory(true);
// Before
queryFactory.setCondition('Id in :subjectIds AND (AssignedSalesRep__c == null OR AssignedSalesRep__r.Name = \'Rusty Shackleford\')');
// After
queryFactory.setCondition(fflib_WhereBuilder
    .whereX('Id in :subjectIds')
    .andX(fflib_WhereBuilder
        .orX(
             'AssignedSalesRep__c == null',
             'AssignedSalesRep__r.Name = \'Rusty Shackleford\''
        )
    ).toString());
// Or inline
queryFactory.setCondition(fflib_WhereBuilder.whereX('Id in :subjectIds').andX(fflib_WhereBuilder.orX('AssignedSalesRep__c == null', 'AssignedSalesRep__r.Name = \'Rusty Shackleford\'')).toString());
// Or extract-refactor out query building into function(s) as you wish
```

If this is approved, I'd be willing to add an overload to QueryFactory for `setCondition(fflib_WhereBuilder);` before the merge.