### PR TITLE
Fix bug in the getChangedRecords method

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
@@ -301,7 +301,10 @@ public virtual with sharing class fflib_SObjectDomain
 			SObject oldRecord = this.ExistingRecords.get(recordId);
 			for (String fieldName : fieldNames)
 			{
-				if (oldRecord.get(fieldName) != newRecord.get(fieldName))
+				Object oldValue = oldRecord.get(fieldName);
+				Object newValue = newRecord.get(fieldName);
+				if (((oldValue instanceof String || newValue instanceof String)	&& oldValue !== newValue)
+						||	oldValue != newValue)
 				{
 					changedRecords.add(newRecord);
 					break;  // prevents the records from being added multiple times
@@ -328,7 +331,10 @@ public virtual with sharing class fflib_SObjectDomain
 			SObject oldRecord = this.ExistingRecords.get(recordId);
 			for (Schema.SObjectField fieldToken : fieldTokens)
 			{
-				if (oldRecord.get(fieldToken) != newRecord.get(fieldToken))
+				Object oldValue = oldRecord.get(fieldToken);
+				Object newValue = newRecord.get(fieldToken);
+				if (((oldValue instanceof String || newValue instanceof String)	&& oldValue !== newValue)
+						||	oldValue != newValue)
 				{
 					changedRecords.add(newRecord);
 					break;  // prevents the records from being added multiple times


### PR DESCRIPTION
A colleague at work found an issue with the getChangedRecords method, it is not listing records as changed when only a casing is different in a field. e.g. LastName field changed from "smith" to "Smith".

e.g.:
This fails: as it outputs "Not Changed"'
```java
Contact r1 = new Contact(LastName = 'Test');
Contact r2 = new Contact(LastName = 'test');
SObjectField fieldName = Contact.LastName;
if (r1.get(fieldName) != r2.get(fieldName))
{
    System.debug('Changed');
} else 
{
   System.debug('Not Changed');
}
```
while this works:
```java
Contact r1 = new Contact(LastName = 'Test');
Contact r2 = new Contact(LastName = 'test');
SObjectField fieldName = Contact.LastName;
if (r1.get(fieldName) !== r2.get(fieldName))
{
    System.debug('Changed');
} else 
{
   System.debug('Not Changed');
}
```

So, instead of `!=` we need to use `!==`

CC: @stohn777 @daveespo @ImJohnMDaniel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/387)
<!-- Reviewable:end -->
