### PR TITLE
fflib_SecurityUtilsTest: Applying permission set to Read Only profile user

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
@@ -80,8 +80,9 @@ private class fflib_SecurityUtilsTest {
 
 	static User setupTestUser(String profileName){
 		Profile p;
-		Boolean usedMinimumAccessProfile = false;
+		Boolean applyReadOnlyPermissionSet = false;
 		if (profileName == 'Read Only') {
+			applyReadOnlyPermissionSet = true;
 			try {
 				p = getProfile(profileName);
 			} catch (QueryException ex) {
@@ -89,7 +90,6 @@ private class fflib_SecurityUtilsTest {
 					// #315 If the "Read Only" Profile is absent, then assume it's a Spring '21 org and see if there's a
 					// "Minimum Access - Salesforce" Profile we can use instead.
 					p = getProfile('Minimum Access - Salesforce');
-					usedMinimumAccessProfile = true;
 				}
 			}
 		} else {
@@ -117,7 +117,7 @@ private class fflib_SecurityUtilsTest {
 		);
 		insert usr;
 
-		if (usedMinimumAccessProfile) {
+		if (applyReadOnlyPermissionSet) {
 			// #315 We need to assign the Perm Set to grant Account "Read" access
 			PermissionSet accountReadPS = [SELECT Id FROM PermissionSet WHERE Name = 'ReadOnlyPermissionSet'];
 			PermissionSetAssignment psa = new PermissionSetAssignment(AssigneeId = usr.Id, PermissionSetId = accountReadPS.Id);


### PR DESCRIPTION
When using the `Read Only` profile to construct the RunAs user, apply the same permission set used for the `Minimum Access - Salesforce`.
This ensures that the user has the expected visibility on the Contact.Birthdate field.

Fixes: #397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/398)
<!-- Reviewable:end -->
