### PR TITLE
Replace implementations on the fly

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -168,6 +168,20 @@ public virtual class fflib_Application
 			return serviceImpl.newInstance();
 		}
 
+		/**
+		 * Creates or replaces an existing binding for another
+		 *
+		 * @param serviceInterfaceType The Interface type to replace its implementation
+		 * @param replacementImplType The implementation type of the replacement
+		 */
+		public virtual void replaceWith(Type serviceInterfaceType, Type replacementImplType)
+		{
+			this.m_serviceInterfaceTypeByServiceImplType.put(
+					serviceInterfaceType,
+					replacementImplType
+			);
+		}
+
 		@TestVisible
 		protected virtual void setMock(Type serviceInterfaceType, Object serviceImpl)
 		{
@@ -268,6 +282,17 @@ public virtual class fflib_Application
 					relatedIds.add(relatedId);
 			}
 			return selectById(relatedIds);
+		}
+
+		/**
+		 * Creates or replaces an existing binding for another
+		 *
+		 * @param sObjectType The SObjectType of the selector to replace
+		 * @param replacementImplType The implementation type of the replacement
+		 */
+		public virtual void replaceWith(SObjectType sObjectType, Type replacementImplType)
+		{
+			this.m_sObjectBySelectorType.put(sObjectType, replacementImplType);
 		}
 
 		@TestVisible
@@ -410,6 +435,28 @@ public virtual class fflib_Application
 					(List<Object>) records,
 					(Object) domainSObjectType
 			);
+		}
+
+		/**
+		 * Creates or replaces an existing binding for another
+		 *
+		 * @param sObjectType The SObjectType of the domain to replace
+		 * @param replacementImplType The implementation type of the replacement
+		 */
+		public virtual void replaceWith(SObjectType sObjectType, Type replacementImplType)
+		{
+			replaceWith((Object) sObjectType, replacementImplType);
+		}
+
+		/**
+		 * Creates or replaces an existing binding for another
+		 *
+		 * @param objectType The objectType of the domain to replace
+		 * @param replacementImplType The implementation type of the replacement
+		 */
+		public virtual void replaceWith(Object objectType, Type replacementImplType)
+		{
+			this.constructorTypeByObject.put( objectType, replacementImplType);
 		}
 
 		@TestVisible

--- a/sfdx-source/apex-common/main/classes/fflib_IDomainFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomainFactory.cls
@@ -25,8 +25,74 @@
 **/
 public interface fflib_IDomainFactory
 {
+	/**
+	 * Dynamically constructs an instance of a Domain class for the given record Ids
+	 *   Internally uses the Selector Factory to query the records before passing to a
+	 *   dynamically constructed instance of the application Apex Domain class
+	 *
+	 * @param recordIds A list of Id's of the same type
+	 * @exception Throws an exception via the Selector Factory if the Ids are not all of the same SObjectType
+	 *
+	 * @return Instance of the Domain
+	 **/
 	fflib_IDomain newInstance(Set<Id> recordIds);
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A concrete list of records, e.g.; `List<Account>` or `List<SObject>`)
+	 *
+	 * @exception Throws an exception if the SObjectType cannot be determined from the list
+	 *              or the constructor for Domain class was not registered for the SObjectType
+	 *
+	 * @return Instance of the Domain containing the given records
+	 **/
 	fflib_IDomain newInstance(List<SObject> records);
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param objects A concrete list of Objects, e.g.; `List<Account>` or `List<SObject>`)
+	 * @param objectType
+	 *
+	 * @exception Throws an exception if the SObjectType cannot be determined from the list
+	 *              or the constructor for Domain class was not registered for the SObjectType
+	 *
+	 * @return Instance of the Domain containing the given Objects
+	 **/
 	fflib_IDomain newInstance(List<Object> objects, Object objectType);
+
+	/**
+	 * Dynamically constructs an instance of the Domain class for the given records and SObjectType
+	 *   Will return a Mock implementation if one has been provided via setMock
+	 *
+	 * @param records A list records
+	 * @param sObjectType SObjectType for list of records
+	 *
+	 * @exception Throws an exception if the SObjectType is not specified or if constructor for Domain class was not registered for the SObjectType
+	 *
+	 * @remark Will support List<SObject> but all records in the list will be assumed to be of
+	 *         the type specified in sObjectType
+	 *
+	 * @return Instance of the Domain containing the given records
+	 **/
 	fflib_IDomain newInstance(List<SObject> records, SObjectType domainSObjectType);
+
+	/**
+	 * Creates or replaces an existing binding for another
+	 *
+	 * @param sObjectType The SObjectType of the domain to replace
+	 * @param replacementImplType The implementation type of the replacement
+	 */
+	void replaceWith(Schema.SObjectType sObjectType, Type replacementImplType);
+
+	/**
+	 * Creates or replaces an existing binding for another
+	 *
+	 * @param objectType The objectType of the domain to replace
+	 * @param replacementImplType The implementation type of the replacement
+	 */
+	void replaceWith(Object objectType, Type replacementImplType);
 }

--- a/sfdx-source/apex-common/main/classes/fflib_ISelectorFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISelectorFactory.cls
@@ -25,7 +25,49 @@
 **/
 public interface fflib_ISelectorFactory
 {
+	/**
+	 * Creates a new instance of the associated Apex Class implementing fflib_ISObjectSelector
+	 *   for the given SObjectType, or if provided via setMock returns the Mock implementation
+	 *
+	 * @param sObjectType An SObjectType token, e.g. Account.SObjectType
+	 *
+	 * @return Instance of fflib_ISObjectSelector
+	 **/
 	fflib_ISObjectSelector newInstance(SObjectType sObjectType);
+
+	/**
+	 * Helper method to query the given SObject records
+	 *   Internally creates an instance of the registered Selector and calls its
+	 *     selectSObjectById method
+	 *
+	 * @param recordIds The SObject record Ids, must be all the same SObjectType
+	 * @exception Is thrown if the record Ids are not all the same or the SObjectType is not registered
+	 *
+	 * @return List of queried records
+	 **/
 	List<SObject> selectById(Set<Id> recordIds);
+
+	/**
+	 * Helper method to query related records to those provided, for example
+	 *   if passed a list of Opportunity records and the Account Id field will
+	 *   construct internally a list of Account Ids and call the registered
+	 *   Account selector to query the related Account records, e.g.
+	 *
+	 *     List<Account> accounts =
+	 *        (List<Account>) Application.Selector.selectByRelationship(myOpps, Opportunity.AccountId);
+	 *
+	 * @param relatedRecords used to extract the related record Ids, e.g. Opportunity records
+	 * @param relationshipField field in the passed records that contains the relationship records to query, e.g. Opportunity.AccountId
+	 *
+	 * @return List of queried records
+	 **/
 	List<SObject> selectByRelationship(List<SObject> relatedRecords, SObjectField relationshipField);
+
+	/**
+	 * Creates or replaces an existing binding for another
+	 *
+	 * @param sObjectType The SObjectType of the selector to replace
+	 * @param replacementImplType The implementation type of the replacement
+	 */
+	void replaceWith(Schema.SObjectType sObjectType, Type replacementImplType);
 }

--- a/sfdx-source/apex-common/main/classes/fflib_IServiceFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IServiceFactory.cls
@@ -25,5 +25,23 @@
 **/
 public interface fflib_IServiceFactory
 {
+	/**
+	 * Returns a new instance of the Apex class associated with the given Apex interface
+	 *   Will return any mock implementation of the interface provided via setMock
+	 *   Note that this method will not check the configured Apex class actually implements the interface
+	 *
+	 * @param serviceInterfaceType Apex interface type
+	 * @exception Is thrown if there is no registered Apex class for the interface type
+	 *
+	 * @return Instance of the requested service class interface type
+	 **/
 	Object newInstance(Type serviceInterfaceType);
+
+	/**
+	 * Creates or replaces an existing binding for another
+	 *
+	 * @param serviceInterfaceType The Interface type to replace its implementation
+	 * @param replacementImplType The implementation type of the replacement
+	 */
+	void replaceWith(Type serviceInterfaceType, Type replacementImplType);
 }


### PR DESCRIPTION
Adds a method to change implementations in realtime using the Application class for Domains, Services and Selectors.

Useful when you want to dynamically assign/change implementation while doing A/B testing or feature switching.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/403)
<!-- Reviewable:end -->
