### PR TITLE
Add domain methods to retrieve maps

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -112,6 +112,58 @@ public virtual class fflib_SObjects
 	}
 
 	/**
+	 * Get a map with the values of two Id fields
+	 * Key fields containing null values are omitted
+	 *
+	 * @param valueField The Id field to use as the Value of the Map
+	 * @param keyField The Id field to use as the Key of the map
+	 *
+	 * @return Returns a map with the values of two fields
+	 *
+	 * @example
+	 * Contacts contacts = Contacts.newInstance(records);
+	 * Map<Id, Id> accountIdByContactId = contacts.getIdFieldByIdField(Contact.AccountId, Contact.Id);
+	 */
+	@TestVisible
+	protected virtual Map<Id, Id> getIdFieldByIdField(Schema.SObjectField valueField, Schema.SObjectField keyField)
+	{
+		Map<Id, Id> result = new Map<Id, Id>();
+		for (SObject record : getRecords())
+		{
+			if (record.get(keyField) == null) continue;
+
+			result.put((Id) record.get(keyField), (Id) record.get(valueField));
+		}
+		return result;
+	}
+
+	/**
+	 * Get a map with the values of a String field as key and Id field
+	 * Key fields containing null values are omitted
+	 *
+	 * @param valueField The Id field to use as the Value of the Map
+	 * @param keyField The String field to use as the Key of the map
+	 *
+	 * @return Returns a map with the values of two fields
+	 *
+	 * @example
+	 * Accounts accounts = Accounts.newInstance(records);
+	 * Map<String, Id> accountIdByName = accounts.getIdFieldByStringField(Schema.Account.Id, Schema.Account.Name);
+	 */
+	@TestVisible
+	protected virtual Map<String, Id> getIdFieldByStringField(Schema.SObjectField valueField, Schema.SObjectField keyField)
+	{
+		Map<String, Id> result = new Map<String, Id>();
+		for (SObject record : getRecords())
+		{
+			if (record.get(keyField) == null) continue;
+
+			result.put((String) record.get(keyField), (Id) record.get(valueField));
+		}
+		return result;
+	}
+
+	/**
 	 * @param sObjectField The Schema.SObjectField to compare against the given value
 	 * @param value The given value of the records sObjectField to include in the return
 	 *
@@ -257,6 +309,31 @@ public virtual class fflib_SObjects
 		return result;
 	}
 
+	/**
+	 * Get a map with the given String field value mapped to the given Id field
+	 * Key fields containing null values are omitted
+	 *
+	 * @param valueField The String field to use as value for the map
+	 * @param keyField The Id field to use as key for the map
+	 *
+	 * @return a map with the given String field value mapped to the given Id field
+	 *
+	 * @example
+	 * Account account = Account.newInstance(records);
+	 * Map<Id, String> accountNameById = account.getStringFieldByIdField(Account.AccountName, Account.Id);
+	 */
+	@TestVisible
+	protected virtual Map<Id, String> getStringFieldByIdField(Schema.SObjectField valueField, Schema.SObjectField keyField)
+	{
+		Map<Id, String> result = new Map<Id, String>();
+		for (SObject record : getRecords())
+		{
+			if (record.get(keyField) == null) continue;
+
+			result.put((Id) record.get(keyField), (String) record.get(valueField));
+		}
+		return result;
+	}
 
 	protected virtual void setFieldValue(Schema.SObjectField sObjectField, Object value)
 	{

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -86,6 +86,55 @@ private class fflib_SObjectsTest
 	}
 
 	@IsTest
+	static void itShouldReturnRecordIdById()
+	{
+		final Id contactId = fflib_IDGenerator.generate(Schema.Contact.SObjectType);
+		final Id accountId = fflib_IDGenerator.generate(Schema.Account.SObjectType);
+		final Contact record = new Contact(Id = contactId, AccountId = accountId);
+		fflib_SObjects domain = new fflib_SObjects(new List<Contact>{ record });
+		System.Test.startTest();
+		Map<Id, Id> accountIdByContactId = domain.getIdFieldByIdField(Schema.Contact.AccountId, Schema.Contact.Id);
+		System.Test.stopTest();
+		System.assert(accountIdByContactId.containsKey(contactId));
+		System.assertEquals(accountId, accountIdByContactId.get(contactId));
+	}
+
+	@IsTest
+	static void itShouldReturnStringById()
+	{
+		final String accountName = 'My Account';
+		final Id accountId = fflib_IDGenerator.generate(Schema.Account.SObjectType);
+		final Account record = new Account(Id = accountId, Name = accountName);
+		fflib_SObjects domain = new fflib_SObjects(new List<Account>{ record });
+		System.Test.startTest();
+		Map<String, Id> nameById = domain.getIdFieldByStringField(Schema.Account.Id, Schema.Account.Name);
+		System.Test.stopTest();
+		System.assert(nameById.containsKey(accountName));
+		System.assertEquals(accountId, nameById.get(accountName));
+	}
+
+	@IsTest
+	static void itShouldReturnStringFieldByIdField()
+	{
+		final String accountName = 'My Account';
+		final Id accountId = fflib_IDGenerator.generate(Account.SObjectType);
+		fflib_SObjects domain = new fflib_SObjects(
+				new List<Account>
+				{
+						new Account(Id = accountId, Name = accountName),
+						new Account(Name = accountName + ' 2')              // This one should be ignored
+				});
+
+		System.Test.startTest();
+		Map<Id, String> result = domain.getStringFieldByIdField(Account.Name, Account.Id);
+		System.Test.stopTest();
+
+		System.assertEquals(1, result.size(), 'Incorrect returned amount of results');
+		System.assert(result.keySet().contains(accountId), 'The accountId is missing from the results');
+		System.assertEquals(accountName, result.get(accountId), 'Incorrect returned account name');
+	}
+
+	@IsTest
 	static void itShouldSetFieldValue()
 	{
 		DomainAccounts domain = generateDomain();


### PR DESCRIPTION
Often we retrieve data from records in maps, these domain methods will help with avoiding iterations.

```
Account accounts = Accounts.newInstance(records);
Map<Id, String> accountNameById = accounts.getStringFieldByIdField(Account.AccountName, Account.Id);
```
instead of:
```
Account accounts = Accounts.newInstance(records);
Map<Id, String> accountNameById = new Map<Id, String>();
for (Account record : (List<Account) accounts.getRecords())
{
  accountNameById.put(record.Id, record.Name);
}
```