### PR TITLE
Add method to include ALL ROWS in QueryFactory

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -666,8 +666,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	/**
 	 * @param addAllRows whether an ALL ROWS clause will be added to the resulting query.
 	**/
-	public fflib_QueryFactory setAllRows(Boolean addAllRows){
-		this.allRows = addAllRows;
+	public fflib_QueryFactory setAllRows(){
+		this.allRows = true;
 		return this;
 	}
 
@@ -713,8 +713,9 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		if(offsetCount != null)
 			result += ' OFFSET '+offsetCount;
 		
-		if(allRows)
+		if(allRows) {
 			result += ' ALL ROWS';
+		}
 
 		return result;
 	}
@@ -728,7 +729,6 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		fflib_QueryFactory clone = new fflib_QueryFactory(this.table)
 			.setLimit(this.limitCount)
 			.setOffset(this.offsetCount)
-			.setAllRows(this.allRows)
 			.setCondition(this.conditionExpression)
 			.setEnforceFLS(this.enforceFLS);
 

--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -664,7 +664,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	}
 
 	/**
-	 * @param addAllRows whether an ALL ROWS clause will be added to the resulting query.
+	 * whether an ALL ROWS clause will be added to the resulting query
 	**/
 	public fflib_QueryFactory setAllRows(){
 		this.allRows = true;

--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -74,6 +74,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	private Boolean enforceFLS;
 	
 	private Boolean sortSelectFields = true;
+	private Boolean allRows = false;
 	
 	/**
 	 * The relationship and  subselectQueryMap variables are used to support subselect queries.  Subselects can be added to 
@@ -663,6 +664,14 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	}
 
 	/**
+	 * @param addAllRows whether an ALL ROWS clause will be added to the resulting query.
+	**/
+	public fflib_QueryFactory setAllRows(Boolean addAllRows){
+		this.allRows = addAllRows;
+		return this;
+	}
+
+	/**
 	 * Convert the values provided to this instance into a full SOQL string for use with Database.query
 	 * Check to see if subqueries queries need to be added after the field list.
 	**/
@@ -703,6 +712,9 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 
 		if(offsetCount != null)
 			result += ' OFFSET '+offsetCount;
+		
+		if(allRows)
+			result += ' ALL ROWS';
 
 		return result;
 	}
@@ -716,6 +728,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		fflib_QueryFactory clone = new fflib_QueryFactory(this.table)
 			.setLimit(this.limitCount)
 			.setOffset(this.offsetCount)
+			.setAllRows(this.allRows)
 			.setCondition(this.conditionExpression)
 			.setEnforceFLS(this.enforceFLS);
 

--- a/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
@@ -564,6 +564,7 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setAllRows(true)
 		.setEnforceFLS(true);
 
 		fflib_QueryFactory qf2 = qf.deepClone();
@@ -584,6 +585,7 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Account','Name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Account','Description',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setAllRows(true)
 		.setEnforceFLS(true);
 
 		qf.subselectQuery('Contacts', true);	
@@ -607,6 +609,7 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
+		.setAllRows(true)
 		.setEnforceFLS(true);
 
 
@@ -693,6 +696,24 @@ private class fflib_QueryFactoryTest {
 		System.assertNotEquals(orderedQuery, actualSoql);
 	}
 
+	@isTest
+	static void testSoql_allRows(){
+		//Given
+		fflib_QueryFactory qf = new fflib_QueryFactory(User.SObjectType);
+		qf.selectField('Id');
+		qf.setAllRows(true);
+
+		String allRowsQuery =
+			'SELECT Id '
+			+'FROM User '
+			+'ALL ROWS';
+
+		//When
+		String actualSoql = qf.toSOQL();
+
+		//Then		
+		System.assertEquals(allRowsQuery, actualSoql);
+	}
 
 	public static User createTestUser_noAccess(){
 		User usr;

--- a/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
@@ -564,7 +564,6 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
-		.setAllRows(true)
 		.setEnforceFLS(true);
 
 		fflib_QueryFactory qf2 = qf.deepClone();
@@ -585,7 +584,6 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Account','Name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Account','Description',fflib_QueryFactory.SortOrder.DESCENDING))
-		.setAllRows(true)
 		.setEnforceFLS(true);
 
 		qf.subselectQuery('Contacts', true);	
@@ -609,7 +607,6 @@ private class fflib_QueryFactoryTest {
 		.selectField('Description')
 		.addOrdering(new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) )
 		.addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING))
-		.setAllRows(true)
 		.setEnforceFLS(true);
 
 
@@ -701,7 +698,7 @@ private class fflib_QueryFactoryTest {
 		//Given
 		fflib_QueryFactory qf = new fflib_QueryFactory(User.SObjectType);
 		qf.selectField('Id');
-		qf.setAllRows(true);
+		qf.setAllRows();
 
 		String allRowsQuery =
 			'SELECT Id '


### PR DESCRIPTION
We have a use case in our project using FFLIB where we need to query for archived and deleted records as well.

The proposed change adds the ability to call `setAllRows(true)` on QueryFactory objects, which results in ALL ROWS being appended to the resulting query. It is also possible to reset the property with `setAllRows(false)` after e.g. deep cloning a QueryFactory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/409)
<!-- Reviewable:end -->
