### PR TITLE
Change addError method to public and virtual

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -79,7 +79,7 @@ public virtual class fflib_SObjects
 	 *
 	 * @param message The error message to add to each record
 	 */
-	protected void addError(String message)
+	public virtual void addError(String message)
 	{
 		for (SObject record : getRecords())
 		{

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -93,8 +93,7 @@ public virtual class fflib_SObjects
 	 * @param field The field where the error should be reported
 	 * @param message The error message to add to the given field on each record
 	 */
-	@TestVisible
-	protected virtual void addError(Schema.SObjectField field, String message)
+	public virtual void addError(Schema.SObjectField field, String message)
 	{
 		for (SObject record : getRecords())
 		{
@@ -106,8 +105,7 @@ public virtual class fflib_SObjects
 	 * Clear the field value on all the records of the domain
 	 * @param field The field to nullify
 	 */
-	@TestVisible
-	protected virtual void clearField(Schema.SObjectField field)
+	public virtual void clearField(Schema.SObjectField field)
 	{
 		clearFields(new Set<Schema.SObjectField>{ field });
 	}
@@ -116,8 +114,7 @@ public virtual class fflib_SObjects
 	 * Clear the field values on all the records of the domain
 	 * @param fields The fields to nullify
 	 */
-	@TestVisible
-	protected virtual void clearFields(Set<Schema.SObjectField> fields)
+	public virtual void clearFields(Set<Schema.SObjectField> fields)
 	{
 		for (SObject record : getRecords())
 		{

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -54,7 +54,7 @@ public class fflib_SObjectsTest
 		DomainAccounts domain = new DomainAccounts(new List<Account>{ record });
 		System.assert(!domain.selectByShippingCountry('Holland').isEmpty(), 'Incorrect test data');
 
-		domain.clearShippingCountry();
+		domain.clearField(Schema.Account.ShippingCountry);
 
 		System.assert(domain.selectByShippingCountry('Holland').isEmpty(), 'Field should have been nullified');
 	}
@@ -193,6 +193,22 @@ public class fflib_SObjectsTest
 		);
 
 		System.assert(domain.selectByRating('Hot').size() == 1);
+	}
+
+	@IsTest
+	static void itShouldAllowBulkMutatorsFromOutsideDomainHierarchy()
+	{
+		Account recordA = new Account(Name = 'A', ShippingCountry = 'USA');
+		Account recordB = new Account(Name = 'B', ShippingCountry = 'Canada');
+		DomainAccounts domain = new DomainAccounts(new List<Account>{ recordA, recordB });
+
+		domain.addError('Bulk record error');
+		domain.addError(Schema.Account.Name, 'Bulk field error');
+		domain.clearFields(new Set<Schema.SObjectField>{ Schema.Account.ShippingCountry });
+
+		System.assertEquals(2, domain.getRecords().size());
+		System.assertEquals(null, recordA.ShippingCountry);
+		System.assertEquals(null, recordB.ShippingCountry);
 	}
 
 	@IsTest


### PR DESCRIPTION
It can be useful to add one error string to all the records of a domain directly from a service class, therefore it needs to be public.
And it is also useful to change its behaviour just like the other addError methods, therefore adding virtual

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/423)
<!-- Reviewable:end -->
