### PR TITLE
Add fflib_QueryFactory database operation mode support

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -66,6 +66,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	private Integer limitCount;
 	private Integer offsetCount;
 	private List<Ordering> order;
+
 	/**
 	 * Integrate checking for READ Field Level Security within the selectField(s) methods
 	 * This can optionally be enforced (or not) by calling the setEnforceFLS method prior to calling 
@@ -75,6 +76,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	
 	private Boolean sortSelectFields = true;
 	private Boolean allRows = false;
+
+	private fflib_SecurityUtils.OperationMode operationMode;
 	
 	/**
 	 * The relationship and  subselectQueryMap variables are used to support subselect queries.  Subselects can be added to 
@@ -671,6 +674,25 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
 	}
 
+	public fflib_QueryFactory setOperationMode(fflib_SecurityUtils.OperationMode operationMode) {
+		this.operationMode = operationMode;
+		return this;
+	}
+
+	public fflib_QueryFactory withUserMode() {
+		this.setOperationMode(fflib_SecurityUtils.OperationMode.USER_MODE);
+		return this;
+	}
+
+	public fflib_QueryFactory withSystemMode() {
+		this.setOperationMode(fflib_SecurityUtils.OperationMode.SYSTEM_MODE);
+		return this;
+	}
+
+	public String getOperationMode() {
+		return this.operationMode.name();
+	}
+
 	/**
 	 * Convert the values provided to this instance into a full SOQL string for use with Database.query
 	 * Check to see if subqueries queries need to be added after the field list.
@@ -696,9 +718,15 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 				result += ', (' + childRow.toSOQL() + ') ';
 			}	
 		}
-		result += ' FROM ' + (relationship != null ? relationship.getRelationshipName() : table.getDescribe().getName());
+
+		Boolean isSubQuery = relationship != null;
+		result += ' FROM ' + (isSubQuery ? relationship.getRelationshipName() : table.getDescribe().getName());
 		if(conditionExpression != null)
 			result += ' WHERE '+conditionExpression;
+
+		if(operationMode != null && !isSubQuery) {
+			result += ' WITH ' + this.operationMode.name();
+		}
 
 		if(order.size() > 0){
 			result += ' ORDER BY ';
@@ -804,5 +832,5 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 
 	public class InvalidFieldSetException extends Exception{}
 	public class NonReferenceFieldException extends Exception{}
-	public class InvalidSubqueryRelationshipException extends Exception{}	
+	public class InvalidSubqueryRelationshipException extends Exception{}
 }

--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -72,7 +72,16 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * This can optionally be enforced (or not) by calling the setEnforceFLS method prior to calling 
 	 * one of the selectField or selectFieldset methods.
 	**/
-	private Boolean enforceFLS;
+	private Boolean enforceFLS {
+		get;
+		set {
+			if(value == true) {
+				this.setOperationMode(null);
+			}
+
+			this.enforceFLS = value;
+		}
+	}
 	
 	private Boolean sortSelectFields = true;
 	private Boolean allRows = false;
@@ -674,8 +683,12 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
 	}
 
-	public fflib_QueryFactory setOperationMode(fflib_SecurityUtils.OperationMode operationMode) {
-		this.operationMode = operationMode;
+	public fflib_QueryFactory setOperationMode(fflib_SecurityUtils.OperationMode mode) {
+		this.operationMode = mode;
+		if(mode != null) {
+			this.setEnforceFLS(false);
+		}
+
 		return this;
 	}
 
@@ -690,7 +703,20 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	}
 
 	public String getOperationMode() {
-		return this.operationMode.name();
+		return this.operationMode?.name();
+	}
+
+	public Boolean isEnforcingFLS()
+	{
+		if(this.isEnforcingUserMode()) {
+			return true;
+		}
+
+		return enforceFLS;
+	}
+
+	private Boolean isEnforcingUserMode() {
+		return this.operationMode == fflib_SecurityUtils.OperationMode.USER_MODE;
 	}
 
 	/**

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -48,11 +48,23 @@ public abstract with sharing class fflib_SObjectSelector
      * Should this selector automatically include the FieldSet fields when building queries?
      **/
     private Boolean m_includeFieldSetFields = false;
+
+    private fflib_SecurityUtils.OperationMode operationMode;
     
     /**
      * Enforce FLS Security
      **/
-    private Boolean m_enforceFLS = false;
+    private Boolean m_enforceFLS
+    {
+        get;
+        set {
+            if(value == true) {
+                this.setOperationMode(null);
+            }
+
+            this.m_enforceFLS = value;
+        }
+    }
 
     /**
      * Enforce CRUD Security
@@ -100,7 +112,9 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Constructs the Selector with the default settings
      **/
-    public fflib_SObjectSelector() { }
+    public fflib_SObjectSelector() {
+        this(false, true, false);
+    }
     
     /**
      * Constructs the Selector
@@ -186,6 +200,34 @@ public abstract with sharing class fflib_SObjectSelector
         return this;
     }
 
+
+
+    public fflib_SObjectSelector withUserMode() {
+        this.setOperationMode(fflib_SecurityUtils.OperationMode.USER_MODE);
+        return this;
+    }
+
+    public fflib_SObjectSelector withSystemMode() {
+        this.setOperationMode(fflib_SecurityUtils.OperationMode.SYSTEM_MODE);
+        return this;
+    }
+
+    public fflib_SObjectSelector setOperationMode(fflib_SecurityUtils.OperationMode mode) {
+        this.operationMode = mode;
+        if(mode != null) {
+            this.ignoreCRUD();
+            this.m_enforceFLS = false;
+        } else {
+            this.m_enforceCRUD = true;
+        }
+
+        return this;
+    }
+
+    public String getOperationMode() {
+        return this.operationMode?.name();
+    }
+
     /**
      * @description Set the selector to automatically include the FieldSet fields when building queries
      **/
@@ -224,6 +266,10 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     public Boolean isEnforcingFLS()
     {
+        if(this.isEnforcingUserMode()) {
+            return true;
+        }
+
     	return m_enforceFLS;
     }
     
@@ -232,8 +278,17 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     public Boolean isEnforcingCRUD()
     {
+        if(this.isEnforcingUserMode()) {
+            return true;
+        }
+
     	return m_enforceCRUD;
     }
+
+    private Boolean isEnforcingUserMode() {
+        return this.operationMode == fflib_SecurityUtils.OperationMode.USER_MODE;
+    }
+
 
     /**
      * Provides access to the builder containing the list of fields base queries are using, this is demand
@@ -369,7 +424,8 @@ public abstract with sharing class fflib_SObjectSelector
     	// Construct QueryFactory around the given SObject
         return configureQueryFactory(
         	new fflib_QueryFactory(getSObjectType2()), 
-        		assertCRUD, enforceFLS, includeSelectorFields);
+        		assertCRUD, enforceFLS, includeSelectorFields)
+                .setOperationMode(this.operationMode);
     }
 
      /**

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -59,7 +59,7 @@ public abstract with sharing class fflib_SObjectSelector
         get;
         set {
             if(value == true) {
-                this.setOperationMode(null);
+                this.operationMode = null;
             }
 
             this.m_enforceFLS = value;

--- a/sfdx-source/apex-common/main/classes/fflib_SecurityUtils.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SecurityUtils.cls
@@ -33,6 +33,7 @@ public class fflib_SecurityUtils
     @TestVisible
     private enum OperationType { CREATE, READ, MODIFY, DEL } //UPDATE and DELETE are reserved words
 
+    public enum OperationMode { SYSTEM_MODE, USER_MODE }
     /**
      * SecurityException is never be thrown directly by fflib_SecurityUtils, instead all 
      * forms of CRUD and FLD violations throw subclasses of it. It is provided as a convenience

--- a/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
@@ -35,7 +35,7 @@ private class fflib_QueryFactoryTest {
 		qf.selectFields( new Set<String>{'acCounTId', 'account.name'} );
 		qf.selectFields( new List<String>{'homePhonE','fAX'} );
 		qf.selectFields( new List<Schema.SObjectField>{ Contact.Email, Contact.Title } );
-		System.assertEquals(new Set<String>{
+		Assert.areEqual(new Set<String>{
 			'FirstName',
 			'LastName',
 			'AccountId',
@@ -52,11 +52,11 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('NAMe').selectFields( new Set<String>{'naMe', 'email'});
 		String query = qf.toSOQL();
-		System.assert( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
-		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 		qf.setLimit(100);
-		System.assertEquals(100,qf.getLimit());
-		System.assert( qf.toSOQL().endsWithIgnoreCase('LIMIT '+qf.getLimit()), 'Failed to respect limit clause:'+qf.toSOQL() );
+		Assert.areEqual(100,qf.getLimit());
+		Assert.isTrue( qf.toSOQL().endsWithIgnoreCase('LIMIT '+qf.getLimit()), 'Failed to respect limit clause:'+qf.toSOQL() );
 	}
 
 	@isTest
@@ -66,9 +66,9 @@ private class fflib_QueryFactoryTest {
 		qf.selectField('name');
 		qf.selectField('email');
 		qf.setCondition( whereClause );
-		System.assertEquals(whereClause,qf.getCondition()); 
+		Assert.areEqual(whereClause,qf.getCondition());
 		String query = qf.toSOQL();
-		System.assert(query.endsWith('WHERE name = \'test\''),'Query should have ended with a filter on name, got: '+query);
+		Assert.isTrue(query.endsWith('WHERE name = \'test\''),'Query should have ended with a filter on name, got: '+query);
 	}
 
 	@isTest
@@ -76,20 +76,20 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('NAMe').selectFields( new Set<String>{'naMe', 'email'});
 		String query = qf.toSOQL();
-		System.assertEquals(1, query.countMatches('Name'), 'Expected one name field in query: '+query );
+		Assert.areEqual(1, query.countMatches('Name'), 'Expected one name field in query: '+query );
 	}
 
 	@isTest
 	static void equalityCheck(){
 		fflib_QueryFactory qf1 = new fflib_QueryFactory(Contact.SObjectType);
 		fflib_QueryFactory qf2 = new fflib_QueryFactory(Contact.SObjectType);
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 		qf1.selectField('name');
-		System.assertNotEquals(qf1,qf2);
+		Assert.areNotEqual(qf1,qf2);
 		qf2.selectField('NAmE');
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 		qf1.selectField('name').selectFields( new Set<String>{ 'NAME', 'name' }).selectFields( new Set<Schema.SObjectField>{ Contact.Name, Contact.Name} );
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 	}
 
 	@isTest
@@ -101,7 +101,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.NonReferenceFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
+		Assert.areNotEqual(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
 	}
 
 	@isTest
@@ -113,7 +113,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
+		Assert.areNotEqual(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
 	}
 
 	@isTest
@@ -140,7 +140,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException e){
 			exceptions.add(e);
 		}
-		System.assertEquals(4,exceptions.size());
+		Assert.areEqual(4,exceptions.size());
 	}
 
 	@isTest
@@ -152,13 +152,13 @@ private class fflib_QueryFactoryTest {
 		qf.addOrdering( new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) ).addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING) );
 		String query = qf.toSOQL();
 
-		System.assertEquals(2,qf.getOrderings().size());
-		System.assertEquals('Name',qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[1].getDirection() );
+		Assert.areEqual(2,qf.getOrderings().size());
+		Assert.areEqual('Name',qf.getOrderings()[0].getField() );
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[1].getDirection() );
 
 		
-		System.assert( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
-		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 	}
 
 	@isTest
@@ -171,36 +171,36 @@ private class fflib_QueryFactoryTest {
 		//test base method with ordeting by OwnerId Descending
 		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','OwnerId',fflib_QueryFactory.SortOrder.DESCENDING) );
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
-		System.assertEquals(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
+		Assert.areEqual(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by LastModifiedDate Ascending
 		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.ASCENDING, true);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedDate Descending
 		qf.setOrdering(Contact.CreatedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.CreatedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.CreatedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedBy.Name Descending
 		qf.setOrdering('CreatedBy.Name', fflib_QueryFactory.SortOrder.DESCENDING);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by Birthdate Ascending
 		qf.setOrdering(Contact.Birthdate, fflib_QueryFactory.SortOrder.ASCENDING);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.Birthdate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.Birthdate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		String query = qf.toSOQL();
 	}
@@ -215,7 +215,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -228,7 +228,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -242,7 +242,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -258,20 +258,20 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
 	static void invalidFields_noQueryField(){
 		try {
 			String path = fflib_QueryFactory.getFieldTokenPath(null);
-			System.assert(false,'Expected InvalidFieldException; none was thrown');
+			Assert.isTrue(false,'Expected InvalidFieldException; none was thrown');
 		} 
 		catch (fflib_QueryFactory.InvalidFieldException ife) {
 			//Expected
 		}
 		catch (Exception e){
-			System.assert(false,'Expected InvalidFieldException; ' + e.getTypeName() + ' was thrown instead: ' + e);
+			Assert.isTrue(false,'Expected InvalidFieldException; ' + e.getTypeName() + ' was thrown instead: ' + e);
 		}
 	}
 
@@ -279,7 +279,7 @@ private class fflib_QueryFactoryTest {
 	static void queryFieldsNotEquals(){
 		String qfld = fflib_QueryFactory.getFieldTokenPath(Contact.Name);
 		String qfld2 = fflib_QueryFactory.getFieldTokenPath(Contact.LastName);
-		System.assert(!qfld.equals(qfld2));	
+		Assert.isTrue(!qfld.equals(qfld2));
 	}
 
 	@isTest
@@ -290,8 +290,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery('Tasks', true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -304,8 +304,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery('Tasks').selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -327,8 +327,8 @@ private class fflib_QueryFactoryTest {
        	//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(relationship, true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -350,8 +350,8 @@ private class fflib_QueryFactoryTest {
        	//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(relationship).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -370,7 +370,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;   
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -381,8 +381,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(Task.SObjectType, true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -402,15 +402,15 @@ private class fflib_QueryFactoryTest {
                 relationship = childRow;
             }
         }
-        System.assert(qf.getSubselectQueries() == null);
+        Assert.isTrue(qf.getSubselectQueries() == null);
 		fflib_QueryFactory childQf = qf.subselectQuery(Task.SObjectType);
 		childQf.assertIsAccessible();
 		childQf.setEnforceFLS(true);
 		childQf.selectField('Id');
 		fflib_QueryFactory childQf2 = qf.subselectQuery(Task.SObjectType);
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(queries.size() == 1);
+		Assert.isTrue(queries != null);
+		Assert.isTrue(queries.size() == 1);
 	}
 
 	@isTest
@@ -429,7 +429,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -450,7 +450,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;   
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -472,9 +472,9 @@ private class fflib_QueryFactoryTest {
 		  .addOrdering(Contact.CreatedDate,fflib_QueryFactory.SortOrder.DESCENDING, true);
 		Set<String> fields = qf.getSelectedFields();
 		fflib_QueryFactory.Ordering ordering = new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING);
-		System.assertEquals('Name',ordering.getField());
+		Assert.areEqual('Name',ordering.getField());
 
-		System.assertEquals(new Set<String>{
+		Assert.areEqual(new Set<String>{
 			'CreatedBy.Name',
 			'LastModifiedById',
 			'LastModifiedDate',
@@ -483,7 +483,7 @@ private class fflib_QueryFactoryTest {
 			'FirstName'},
 			fields);
 
-		System.assert(qf.toSOQL().containsIgnoreCase('NULLS LAST'));
+		Assert.isTrue(qf.toSOQL().containsIgnoreCase('NULLS LAST'));
 	}
 
 	@isTest
@@ -500,7 +500,7 @@ private class fflib_QueryFactoryTest {
 				} catch (fflib_SecurityUtils.CrudException e) {
 					excThrown = true;
 				}	
-				System.assert(excThrown);
+				Assert.isTrue(excThrown);
 			}	
 		}	
 	}  
@@ -520,7 +520,7 @@ private class fflib_QueryFactoryTest {
 				} catch (fflib_SecurityUtils.FlsException e) {
 					excThrown = true;
 				}	
-				System.assert(excThrown);
+				Assert.isTrue(excThrown);
 			}	
 		}	
 	}
@@ -530,7 +530,7 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.assertIsAccessible().setEnforceFLS(true).setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING);
 		String query = qf.toSOQL();
-		System.assert(query.containsIgnoreCase('SELECT Id FROM Contact'),'Expected \'SELECT Id FROM Contact\' in the SOQL, found: ' + query);
+		Assert.isTrue(query.containsIgnoreCase('SELECT Id FROM Contact'),'Expected \'SELECT Id FROM Contact\' in the SOQL, found: ' + query);
 	}  
 
 	@isTest
@@ -551,9 +551,9 @@ private class fflib_QueryFactoryTest {
 			'SELECT CreatedBy.ManagerId, CreatedBy.Name, '
 			+'FirstName, Id, LastModifiedBy.Email, LastName '
 			+'FROM User';
-		System.assertEquals(qf1.toSOQL(), qf2.toSOQL());
-		System.assertEquals(expectedQuery, qf1.toSOQL());
-		System.assertEquals(expectedQuery, qf2.toSOQL());
+		Assert.areEqual(qf1.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(expectedQuery, qf1.toSOQL());
+		Assert.areEqual(expectedQuery, qf2.toSOQL());
 	}
 
 	@isTest
@@ -568,12 +568,12 @@ private class fflib_QueryFactoryTest {
 
 		fflib_QueryFactory qf2 = qf.deepClone();
 
-		System.assertEquals(qf2, qf);
+		Assert.areEqual(qf2, qf);
 
-		System.assertEquals(qf.getLimit(), qf2.getLimit());
-		System.assertEquals(qf.getCondition(), qf2.getCondition());
-		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
-		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
+		Assert.areEqual(qf.getLimit(), qf2.getLimit());
+		Assert.areEqual(qf.getCondition(), qf2.getCondition());
+		Assert.areEqual(qf.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(qf.getOrderings(), qf2.getOrderings());
 	}
 
 	@isTest
@@ -590,13 +590,13 @@ private class fflib_QueryFactoryTest {
 
 		fflib_QueryFactory qf2 = qf.deepClone();
 
-		System.assertEquals(qf, qf2);
+		Assert.areEqual(qf, qf2);
 
-		System.assertEquals(qf.getLimit(), qf2.getLimit());
-		System.assertEquals(qf.getCondition(), qf2.getCondition());
-		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
-		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
-		System.assertEquals(qf.getSubselectQueries(), qf2.getSubselectQueries());
+		Assert.areEqual(qf.getLimit(), qf2.getLimit());
+		Assert.areEqual(qf.getCondition(), qf2.getCondition());
+		Assert.areEqual(qf.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(qf.getOrderings(), qf2.getOrderings());
+		Assert.areEqual(qf.getSubselectQueries(), qf2.getSubselectQueries());
 	}
 
 	@isTest
@@ -619,27 +619,27 @@ private class fflib_QueryFactoryTest {
 
 		qf2.getOrderings().remove(0);
 
-		System.assertEquals(10, qf.getLimit());
-		System.assertEquals(200, qf2.getLimit());
+		Assert.areEqual(10, qf.getLimit());
+		Assert.areEqual(200, qf2.getLimit());
 
-		System.assertEquals('id=12345', qf.getCondition());
-		System.assertEquals('id=54321', qf2.getCondition());
+		Assert.areEqual('id=12345', qf.getCondition());
+		Assert.areEqual('id=54321', qf2.getCondition());
 
 		String query = qf.toSOQL();
 		String query2 = qf2.toSOQL();
 
-		System.assert(query.containsIgnoreCase('Fax') == false);
-		System.assert(query.containsIgnoreCase('Description'));
-		System.assert(query2.containsIgnoreCase('Description'));
-		System.assert(query2.containsIgnoreCase('Fax'));
+		Assert.isTrue(query.containsIgnoreCase('Fax') == false);
+		Assert.isTrue(query.containsIgnoreCase('Description'));
+		Assert.isTrue(query2.containsIgnoreCase('Description'));
+		Assert.isTrue(query2.containsIgnoreCase('Fax'));
 
-		System.assertEquals(2, qf.getOrderings().size());
-		System.assertEquals('Name', qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[1].getDirection());
+		Assert.areEqual(2, qf.getOrderings().size());
+		Assert.areEqual('Name', qf.getOrderings()[0].getField() );
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[1].getDirection());
 
-		System.assertEquals(2, qf2.getOrderings().size());
-		System.assertEquals('Fax', qf2.getOrderings()[1].getField());
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf2.getOrderings()[1].getDirection());
+		Assert.areEqual(2, qf2.getOrderings().size());
+		Assert.areEqual('Fax', qf2.getOrderings()[1].getField());
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf2.getOrderings()[1].getDirection());
 
 	}
 
@@ -658,11 +658,11 @@ private class fflib_QueryFactoryTest {
 
 		subquery2_0.addOrdering(new fflib_QueryFactory.Ordering('Contact','Name',fflib_QueryFactory.SortOrder.ASCENDING));
 
-		System.assert(subqueries.size() == 1);
-		System.assert(subqueries2.size() == 2);
+		Assert.isTrue(subqueries.size() == 1);
+		Assert.isTrue(subqueries2.size() == 2);
 
-		System.assert(qf.getSubselectQueries().get(0).getOrderings().size() == 0);
-		System.assert(qf2.getSubselectQueries().get(0).getOrderings().size() == 1);
+		Assert.isTrue(qf.getSubselectQueries().get(0).getOrderings().size() == 0);
+		Assert.isTrue(qf2.getSubselectQueries().get(0).getOrderings().size() == 1);
 	}
 	
 	@isTest
@@ -689,8 +689,8 @@ private class fflib_QueryFactoryTest {
 		//When
 		String actualSoql = qf.toSOQL();
 
-		//Then		
-		System.assertNotEquals(orderedQuery, actualSoql);
+		//Then
+		Assert.areNotEqual(orderedQuery, actualSoql);
 	}
 
 	@isTest
@@ -708,8 +708,44 @@ private class fflib_QueryFactoryTest {
 		//When
 		String actualSoql = qf.toSOQL();
 
-		//Then		
-		System.assertEquals(allRowsQuery, actualSoql);
+		//Then
+		Assert.areEqual(allRowsQuery, actualSoql);
+	}
+
+	@IsTest
+	static void testSoql_SetOperationMode() {
+
+		for(fflib_SecurityUtils.OperationMode mode : fflib_SecurityUtils.OperationMode.values()) {
+			fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+
+			qf.setOperationMode(mode);
+
+			String expectedQuery =
+					'SELECT Id FROM Account WITH ' + mode.name();
+
+			String actualQuery = qf.toSOQL();
+
+			Assert.areEqual(mode.name(), qf.getOperationMode());
+			Assert.areEqual(expectedQuery, actualQuery);
+		}
+
+	}
+	@IsTest
+	static void testSoql_WithUserOperationMode() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+
+		qf.withUserMode();
+
+		Assert.areEqual('USER_MODE', qf.getOperationMode());
+	}
+
+	@IsTest
+	static void testSoql_WithSystemOperationMode() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+
+		qf.withSystemMode();
+
+		Assert.areEqual('SYSTEM_MODE', qf.getOperationMode());
 	}
 
 	public static User createTestUser_noAccess(){

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -554,5 +554,40 @@ private with sharing class fflib_SObjectSelectorTest
 		public Schema.SObjectType getSObjectType() {
 			return Lead.sObjectType;
 		}
-	}	
+	}
+
+	@IsTest
+	static void testSetOperationType() {
+		Testfflib_UserSObjectSelector selector = new Testfflib_UserSObjectSelector();
+		Assert.isTrue(selector.isEnforcingCRUD());
+
+		Assert.isFalse(selector.newQueryFactory().isEnforcingFLS());
+
+		selector.ignoreCRUD();
+		Assert.isFalse(selector.isEnforcingCRUD());
+
+		selector.enforceFLS();
+		Assert.isTrue(selector.isEnforcingFLS());
+		Assert.isTrue(selector.isEnforcingCRUD());
+		Assert.isNull(selector.getOperationMode());
+
+		Assert.areEqual(null, selector.newQueryFactory().getOperationMode());
+		Assert.isTrue(selector.newQueryFactory().isEnforcingFLS());
+
+		selector.withSystemMode();
+		Assert.isFalse(selector.isEnforcingFLS());
+		Assert.isFalse(selector.isEnforcingCRUD());
+		Assert.areEqual('SYSTEM_MODE', selector.getOperationMode());
+
+		Assert.areEqual('SYSTEM_MODE', selector.newQueryFactory().getOperationMode());
+		Assert.isFalse(selector.newQueryFactory().isEnforcingFLS());
+
+		selector.withUserMode();
+		Assert.isTrue(selector.isEnforcingFLS());
+		Assert.isTrue(selector.isEnforcingCRUD());
+		Assert.areEqual('USER_MODE', selector.getOperationMode());
+
+		Assert.areEqual('USER_MODE', selector.newQueryFactory().getOperationMode());
+		Assert.isTrue(selector.newQueryFactory().isEnforcingFLS());
+	}
 }

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -568,7 +568,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		selector.enforceFLS();
 		Assert.isTrue(selector.isEnforcingFLS());
-		Assert.isTrue(selector.isEnforcingCRUD());
+		Assert.isFalse(selector.isEnforcingCRUD());
 		Assert.isNull(selector.getOperationMode());
 
 		Assert.areEqual(null, selector.newQueryFactory().getOperationMode());

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -31,8 +31,8 @@ private with sharing class fflib_SObjectSelectorTest
 	static testMethod void testGetSObjectName()
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
-		system.assertEquals(null, selector.getSObjectFieldSetList());
-		system.assertEquals('Account',selector.getSObjectName());
+		Assert.areEqual(null, selector.getSObjectFieldSetList());
+		Assert.areEqual('Account',selector.getSObjectName());
 	}
 	
 	static testMethod void testSelectSObjectsById()
@@ -51,13 +51,13 @@ private with sharing class fflib_SObjectSelectorTest
 		List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);		
 		Test.stopTest();
 		
-		system.assertEquals(2,result.size());
-		system.assertEquals('TestAccount2',result[0].Name);
-		system.assertEquals('A2',result[0].AccountNumber);
-		system.assertEquals(12345.67,result[0].AnnualRevenue);
-		system.assertEquals('TestAccount1',result[1].Name);
-		system.assertEquals('A1',result[1].AccountNumber);
-		system.assertEquals(76543.21,result[1].AnnualRevenue);
+		Assert.areEqual(2,result.size());
+		Assert.areEqual('TestAccount2',result[0].Name);
+		Assert.areEqual('A2',result[0].AccountNumber);
+		Assert.areEqual(12345.67,result[0].AnnualRevenue);
+		Assert.areEqual('TestAccount1',result[1].Name);
+		Assert.areEqual('A1',result[1].AccountNumber);
+		Assert.areEqual(76543.21,result[1].AnnualRevenue);
 	}
 
 	static testMethod void testQueryLocatorById()
@@ -77,17 +77,17 @@ private with sharing class fflib_SObjectSelectorTest
 		System.Iterator<SObject> iteratorResult = result.iterator();
 		Test.stopTest();		
 
-		System.assert(true, iteratorResult.hasNext());
+		Assert.isTrue(true, String.valueOf(iteratorResult.hasNext()));
 		Account account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount2',account.Name);
-		system.assertEquals('A2',account.AccountNumber);
-		system.assertEquals(12345.67,account.AnnualRevenue);				
-		System.assert(true, iteratorResult.hasNext());
+		Assert.areEqual('TestAccount2',account.Name);
+		Assert.areEqual('A2',account.AccountNumber);
+		Assert.areEqual(12345.67,account.AnnualRevenue);
+		Assert.isTrue(true, String.valueOf(iteratorResult.hasNext()));
 		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount1',account.Name);
-		system.assertEquals('A1',account.AccountNumber);
-		system.assertEquals(76543.21,account.AnnualRevenue);				
-		System.assertEquals(false, iteratorResult.hasNext());
+		Assert.areEqual('TestAccount1',account.Name);
+		Assert.areEqual('A1',account.AccountNumber);
+		Assert.areEqual(76543.21,account.AnnualRevenue);
+		Assert.areEqual(false, iteratorResult.hasNext());
 	}
 	
 	static testMethod void testAssertIsAccessible()
@@ -110,11 +110,11 @@ private with sharing class fflib_SObjectSelectorTest
 			try
 			{
 				List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);
-				System.assert(false,'Expected exception was not thrown');
+				Assert.isTrue(false,'Expected exception was not thrown');
 			}
 			catch(fflib_SObjectDomain.DomainException e)
 			{
-				System.assertEquals('Permission to access an Account denied.',e.getMessage());
+				Assert.areEqual('Permission to access an Account denied.',e.getMessage());
 			}
 		}
 	}
@@ -142,7 +142,7 @@ private with sharing class fflib_SObjectSelectorTest
 			}
 			catch(fflib_SObjectDomain.DomainException e)
 			{
-				System.assert(false,'Did not expect an exception to be thrown');
+				Assert.isTrue(false,'Did not expect an exception to be thrown');
 			}
 		}
 	}
@@ -153,8 +153,8 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = selector.newQueryFactory().toSOQL();
 		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
-		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
-		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
+		Assert.isTrue(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.areEqual(1, m.groupCount(), 'Unexpected number of groups captured.');
 		String fieldListString = m.group(1);
 		assertFieldListString(fieldListString, null);
 	}
@@ -165,8 +165,8 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = selector.newQueryFactory().toSOQL();
 		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name ASC NULLS FIRST ');
 		Matcher m = p.matcher(soql);
-		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
-		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
+		Assert.isTrue(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.areEqual(1, m.groupCount(), 'Unexpected number of groups captured.');
 		String fieldListString = m.group(1);
 		assertFieldListString(fieldListString, null);
 	}
@@ -174,31 +174,31 @@ private with sharing class fflib_SObjectSelectorTest
 	static testMethod void testDefaultConfig()
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
-		System.assertEquals(false, selector.isEnforcingFLS());
-		System.assertEquals(true, selector.isEnforcingCRUD());
-		System.assertEquals(false, selector.isIncludeFieldSetFields());
+		Assert.areEqual(false, selector.isEnforcingFLS());
+		Assert.areEqual(true, selector.isEnforcingCRUD());
+		Assert.areEqual(false, selector.isIncludeFieldSetFields());
 		
-		System.assertEquals('Account', selector.getSObjectName());
-		System.assertEquals(Account.SObjectType, selector.getSObjectType2());
+		Assert.areEqual('Account', selector.getSObjectName());
+		Assert.areEqual(Account.SObjectType, selector.getSObjectType2());
 	}
 	
 	private static void assertFieldListString(String fieldListString, String prefix) {
 		String prefixString = (!String.isBlank(prefix)) ? prefix + '.' : '';
 		List<String> fieldList = fieldListString.split(',{1}\\s?');
-		System.assertEquals(UserInfo.isMultiCurrencyOrganization() ? 5 : 4, fieldList.size()); 
+		Assert.areEqual(UserInfo.isMultiCurrencyOrganization() ? 5 : 4, fieldList.size());
 		Set<String> fieldSet = new Set<String>();
 		fieldSet.addAll(fieldList);
 		String expected = prefixString + 'AccountNumber';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'AnnualRevenue';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'Id';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'Name';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		if (UserInfo.isMultiCurrencyOrganization()) {
 			expected = prefixString + 'CurrencyIsoCode';
-			System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+			Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		}
 	}
 	
@@ -225,7 +225,7 @@ private with sharing class fflib_SObjectSelectorTest
 		soqlMatcher.matches();
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	// Test case of ordering with NULLS LAST option passed into the ordering method
@@ -249,7 +249,7 @@ private with sharing class fflib_SObjectSelectorTest
 		// Assert that the
 		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
+		Assert.isTrue(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
 
 	@IsTest
@@ -271,10 +271,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -296,10 +296,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -321,10 +321,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -344,7 +344,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		List<String> actualSelectFields = fieldListString.deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -363,7 +363,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		List<String> actualSelectFields = fieldListString.deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 
 	}
 
@@ -372,7 +372,7 @@ private with sharing class fflib_SObjectSelectorTest
 		Set<String> expected = new Set<String>(expectedSelectFields.deleteWhiteSpace().split(','));
 		Set<String> actual = new Set<String>(actualSelectFields.deleteWhiteSpace().split(','));
 
-		System.assertEquals(expected, actual);
+		Assert.areEqual(expected, actual);
 	}
 	
 	private class Testfflib_SObjectSelector extends fflib_SObjectSelector
@@ -502,7 +502,7 @@ private with sharing class fflib_SObjectSelectorTest
 		soqlMatcher.matches();
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	private class Testfflib_CampaignMemberSelector extends fflib_SObjectSelector {


### PR DESCRIPTION
# Goal

Add support for [`USER_MODE` and `SYSTEM_MODE` database operation modes](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_enforce_usermode.htm) to fflib_QueryFactory and fflib_SObjectSelector that provides backward compatibility with the existing `enforceFLS` and `enforceCRUD` checks.

## fflib_QueryFactory

When the operation mode is set, the `enforceFLS` is set to false to skip the fflib_SecurityUtils checks.  Alternatively, when you call `setEnforceFLS(true)`, the operation mode is set to null, and fflib_SecurityUtils checks are respected.

### Operation Mode not set
```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
// enforceFLS -> false
qf.getOperationMode(); // null

// SELECT Id FROM Account
```

### Specify `WITH USER_MODE`
```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.withUserMode();
qf.getOperationMode(); // USER_MODE
// enforceFLS -> false
qf.getOperationMode(); // null

// SELECT Id FROM Account WITH USER_MODE

qf.setOperationMode(fflib_SecurityUtils.OperationMode.USER_MODE);
qf.getOperationMode(); // USER_MODE
// enforceFLS -> false

// SELECT Id FROM Account WITH USER_MODE
```

### Specify `WITH SYSTEM_MODE`
Salesforce uses `SYSTEM_MODE` as the default operation mode when not specified in the query.  `withSystemMode()` allows users to make their queries explicit if desired.

```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.withSystemMode();
// enforceFLS -> false

qf.getOperationMode(); // SYSTEM_MODE
// SELECT Id FROM Account WITH SYSTEM_MODE

qf.setOperationMode(fflib_SecurityUtils.OperationMode.SYSTEM_MODE);
// SELECT Id FROM Account WITH SYSTEM_MODE
```

### Works with other clauses
The `WITH {OPERATION_MODE}' clause is inserted after the WHERE clause and before any other clauses

```SQL
SELECT Id FROM Account {WHERE clause} WITH {OPERATION_MODE} {...Other clauses}
```

```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.setCondition(Account.Name + ' IN :names');
qf.setOrdering(Account.Name, fflib_QueryFactory.SortOrder.ASCENDING);
qf.setLimit(2);
// SELECT Id FROM Account WHERE Name IN :names ORDER BY Name ASC NULLS FIRST  LIMIT 2

qf.withUserMode();
// SELECT Id FROM Account WHERE Name IN :names WITH USER_MODE ORDER BY Name ASC NULLS FIRST  LIMIT 2
```

### Only applies to top-level queries
```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.subselectQuery('Contacts');
// SELECT Id, (SELECT Id FROM Contact) FROM Account

qf.withUserMode();
// SELECT Id, (SELECT Id FROM Contacts) FROM Account WITH USER_MODE

qf.withSystemMode();
// SELECT Id, (SELECT Id FROM Contacts) FROM Account WITH SYSTEM_MODE
```

## fflib_SObjectSelector

`isEnforcingFLS()` and `isEnforcingCRUD()` now consider the operation mode to determine their result instead of directly returning the values of `m_enforceFLS` and `m_enforceCRUD`.  This allows the user to get the correct state from the methods, regardless if they are using legacy enforcement or one of the new operation modes.

When the operation mode is set, the `m_enforceFLS` and `m_enforceCRUD` are false.

### Operation Mode not set

`isEnforcingFLS()` and `isEnforcingCRUD()` returns the value of the private properties.    fflib_SecurityUtils checks are respected.

```java
AccountSelector selector = new AccountSelector();

// m_enforceFLS -> false
// m_enforceCRUD -> true
// selector.isEnforcingCRUD() -> true
// selector.isEnforcingFLS() -> false

selector.enforceFLS();
// m_enforceFLS -> true
// selector.isEnforcingFSL() -> true

selector.newQueryFactory();
// query factory enforceFLS -> true;
// SELECT Id FROM Account
```

### Specify `USER_MODE`
`isEnforcingFLS()` and `isEnforcingCRUD()` return true, but the properties are false.  fflib_SecurityUtils checks are skipped.

```java
AccountSelector selector = new AccountSelector();

selector.withUserMode();
// m_enforceFLS -> false
// m_enforceCRUD -> false

// selector.isEnforcingCRUD() -> true
// selector.isEnforcingFLS() -> true

selector.newQueryFactory();
// query factory enforceFLS -> false;
// SELECT Id FROM Account WITH USER_MODE
```

### Specify `SYSTEM_MODE`

`isEnforcingFLS()` and `isEnforcingCRUD()` return false, and the properties are set to false.    fflib_SecurityUtils checks are skipped.

```java
AccountSelector selector = new AccountSelector();

selector.withSystemMode();
// m_enforceFLS -> false
// m_enforceCRUD -> false

// selector.isEnforcingCRUD() -> false
// selector.isEnforcingFLS() -> false

selector.newQueryFactory();
// query factory enforceFLS -> false;
// SELECT Id FROM Account WITH SYSTEM_MODE
```

## Add

### Enum fflib_SecurityUtils.OperationMode

- SYSTEM_MODE
- USER_MODE

### fflib_QueryFactory

- void setOperationType(fflib_SecurityUtils.OperationMode mode)
- void withUserMode()
- void withSystemMode()
- String getOperationMode()
- Boolean isEnforcingFLS();

### fflib_SObjectSelector

- void setOperationType(fflib_SecurityUtils.OperationMode mode)
- void withUserMode()
- void withSystemMode()
- String getOperationMode()

## Change

### fflib_QueryFactoryTest

- Replace System asserts with new Assert class

### fflib_SObjectSelector

- Update `m_enforceFLS` to use getter/setter so when its value is changed to true, then the `operationMode` property will be set to null

### fflib_SObjectSelectorTest

- Replace System asserts with new Assert class

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/434)
<!-- Reviewable:end -->
