### PR TITLE
Add `withUserMode()` and `withSystemMode()` to SObjectSelector and QueryFactory

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -225,6 +225,20 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 		return this;
 	}
 
+	public fflib_QueryFactory withUserMode() {
+		this.setEnforceFLS(FLSEnforcement.USER_MODE);
+		return this;
+	}
+
+	public fflib_QueryFactory withSystemMode() {
+		this.setEnforceFLS(FLSEnforcement.SYSTEM_MODE);
+		return this;
+	}
+
+	public FLSEnforcement getFLSEnforcement() {
+		return this.mFlsEnforcement;
+	}
+
 
 	/**
 	 * Sets a flag to indicate that this query should have ordered

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -202,6 +202,7 @@ public abstract with sharing class fflib_SObjectSelector
     public fflib_SObjectSelector enforceFLS()
     {
         m_enforceFLS = true;
+        this.setDataAccess(DataAccess.LEGACY);
         return this;
     }
 
@@ -238,7 +239,20 @@ public abstract with sharing class fflib_SObjectSelector
             ignoreCRUD();
             m_enforceFLS = false;
         }
+        else {
+            this.m_enforceCRUD = true;
+        }
 
+        return this;
+    }
+
+    public fflib_SObjectSelector withUserMode() {
+        this.setDataAccess(DataAccess.USER_MODE);
+        return this;
+    }
+
+    public fflib_SObjectSelector withSystemMode() {
+        this.setDataAccess(DataAccess.SYSTEM_MODE);
         return this;
     }
 
@@ -255,6 +269,10 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     public Boolean isEnforcingFLS()
     {
+        if(isUserMode()) {
+            return true;
+        }
+
     	return m_enforceFLS;
     }
     
@@ -263,7 +281,15 @@ public abstract with sharing class fflib_SObjectSelector
      **/
     public Boolean isEnforcingCRUD()
     {
+        if(isUserMode()) {
+            return true;
+        }
+
     	return m_enforceCRUD;
+    }
+
+    private Boolean isUserMode() {
+        return this.getDataAccess() == DataAccess.USER_MODE;
     }
 
     public DataAccess getDataAccess(){

--- a/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
@@ -35,7 +35,7 @@ private class fflib_QueryFactoryTest {
 		qf.selectFields( new Set<String>{'acCounTId', 'account.name'} );
 		qf.selectFields( new List<String>{'homePhonE','fAX'} );
 		qf.selectFields( new List<Schema.SObjectField>{ Contact.Email, Contact.Title } );
-		System.assertEquals(new Set<String>{
+		Assert.areEqual(new Set<String>{
 			'FirstName',
 			'LastName',
 			'AccountId',
@@ -52,11 +52,11 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('NAMe').selectFields( new Set<String>{'naMe', 'email'});
 		String query = qf.toSOQL();
-		System.assert( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
-		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 		qf.setLimit(100);
-		System.assertEquals(100,qf.getLimit());
-		System.assert( qf.toSOQL().endsWithIgnoreCase('LIMIT '+qf.getLimit()), 'Failed to respect limit clause:'+qf.toSOQL() );
+		Assert.areEqual(100,qf.getLimit());
+		Assert.isTrue( qf.toSOQL().endsWithIgnoreCase('LIMIT '+qf.getLimit()), 'Failed to respect limit clause:'+qf.toSOQL() );
 	}
 
 	@isTest
@@ -66,9 +66,9 @@ private class fflib_QueryFactoryTest {
 		qf.selectField('name');
 		qf.selectField('email');
 		qf.setCondition( whereClause );
-		System.assertEquals(whereClause,qf.getCondition()); 
+		Assert.areEqual(whereClause,qf.getCondition());
 		String query = qf.toSOQL();
-		System.assert(query.endsWith('WHERE name = \'test\''),'Query should have ended with a filter on name, got: '+query);
+		Assert.isTrue(query.endsWith('WHERE name = \'test\''),'Query should have ended with a filter on name, got: '+query);
 	}
 
 	@isTest
@@ -76,20 +76,20 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.selectField('NAMe').selectFields( new Set<String>{'naMe', 'email'});
 		String query = qf.toSOQL();
-		System.assertEquals(1, query.countMatches('Name'), 'Expected one name field in query: '+query );
+		Assert.areEqual(1, query.countMatches('Name'), 'Expected one name field in query: '+query );
 	}
 
 	@isTest
 	static void equalityCheck(){
 		fflib_QueryFactory qf1 = new fflib_QueryFactory(Contact.SObjectType);
 		fflib_QueryFactory qf2 = new fflib_QueryFactory(Contact.SObjectType);
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 		qf1.selectField('name');
-		System.assertNotEquals(qf1,qf2);
+		Assert.areNotEqual(qf1,qf2);
 		qf2.selectField('NAmE');
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 		qf1.selectField('name').selectFields( new Set<String>{ 'NAME', 'name' }).selectFields( new Set<Schema.SObjectField>{ Contact.Name, Contact.Name} );
-		System.assertEquals(qf1,qf2);
+		Assert.areEqual(qf1,qf2);
 	}
 
 	@isTest
@@ -101,7 +101,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.NonReferenceFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
+		Assert.areNotEqual(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
 	}
 
 	@isTest
@@ -113,7 +113,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
+		Assert.areNotEqual(null,e,'Cross-object notation on a non-reference field should throw NonReferenceFieldException.');
 	}
 
 	@isTest
@@ -140,7 +140,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException e){
 			exceptions.add(e);
 		}
-		System.assertEquals(4,exceptions.size());
+		Assert.areEqual(4,exceptions.size());
 	}
 
 	@isTest
@@ -152,13 +152,13 @@ private class fflib_QueryFactoryTest {
 		qf.addOrdering( new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING) ).addOrdering( new fflib_QueryFactory.Ordering('Contact','CreatedDATE',fflib_QueryFactory.SortOrder.DESCENDING) );
 		String query = qf.toSOQL();
 
-		System.assertEquals(2,qf.getOrderings().size());
-		System.assertEquals('Name',qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[1].getDirection() );
+		Assert.areEqual(2,qf.getOrderings().size());
+		Assert.areEqual('Name',qf.getOrderings()[0].getField() );
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING,qf.getOrderings()[1].getDirection() );
 
 		
-		System.assert( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
-		System.assert( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Name.*FROM.*',query), 'Expected Name field in query, got '+query);
+		Assert.isTrue( Pattern.matches('SELECT.*Email.*FROM.*',query), 'Expected Name field in query, got '+query);
 	}
 
 	@isTest
@@ -171,36 +171,36 @@ private class fflib_QueryFactoryTest {
 		//test base method with ordeting by OwnerId Descending
 		qf.setOrdering( new fflib_QueryFactory.Ordering('Contact','OwnerId',fflib_QueryFactory.SortOrder.DESCENDING) );
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
-		System.assertEquals(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace default Orderings');
+		Assert.areEqual(Contact.OwnerId.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field OwnerId');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by LastModifiedDate Ascending
 		qf.setOrdering('LastModifiedDate', fflib_QueryFactory.SortOrder.ASCENDING, true);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.LastModifiedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field LastModifiedDate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedDate Descending
 		qf.setOrdering(Contact.CreatedDate, fflib_QueryFactory.SortOrder.DESCENDING, true);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.CreatedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.CreatedDate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field CreatedDate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by CreatedBy.Name Descending
 		qf.setOrdering('CreatedBy.Name', fflib_QueryFactory.SortOrder.DESCENDING);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		//test method overload with ordering by Birthdate Ascending
 		qf.setOrdering(Contact.Birthdate, fflib_QueryFactory.SortOrder.ASCENDING);
 
-		System.assertEquals(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
-		System.assertEquals(Contact.Birthdate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
+		Assert.areEqual(1, qf.getOrderings().size(), 'Unexpected order size - setOrder should replace previous Orderings');
+		Assert.areEqual(Contact.Birthdate.getDescribe().getName(), qf.getOrderings()[0].getField(), 'Unexpected order field - should have been resolved from the field Birthdate');
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf.getOrderings()[0].getDirection(), 'Unexpected order direction.');
 
 		String query = qf.toSOQL();
 	}
@@ -215,7 +215,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -228,7 +228,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -242,7 +242,7 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
@@ -258,20 +258,20 @@ private class fflib_QueryFactoryTest {
 		}catch(fflib_QueryFactory.InvalidFieldException ex){
 			e = ex;
 		}
-		System.assertNotEquals(null,e);
+		Assert.areNotEqual(null,e);
 	}
 
 	@isTest
 	static void invalidFields_noQueryField(){
 		try {
 			String path = fflib_QueryFactory.getFieldTokenPath(null);
-			System.assert(false,'Expected InvalidFieldException; none was thrown');
+			Assert.isTrue(false,'Expected InvalidFieldException; none was thrown');
 		} 
 		catch (fflib_QueryFactory.InvalidFieldException ife) {
 			//Expected
 		}
 		catch (Exception e){
-			System.assert(false,'Expected InvalidFieldException; ' + e.getTypeName() + ' was thrown instead: ' + e);
+			Assert.isTrue(false,'Expected InvalidFieldException; ' + e.getTypeName() + ' was thrown instead: ' + e);
 		}
 	}
 
@@ -279,7 +279,7 @@ private class fflib_QueryFactoryTest {
 	static void queryFieldsNotEquals(){
 		String qfld = fflib_QueryFactory.getFieldTokenPath(Contact.Name);
 		String qfld2 = fflib_QueryFactory.getFieldTokenPath(Contact.LastName);
-		System.assert(!qfld.equals(qfld2));	
+		Assert.isTrue(!qfld.equals(qfld2));
 	}
 
 	@isTest
@@ -290,8 +290,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery('Tasks', true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -304,8 +304,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery('Tasks').selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -327,8 +327,8 @@ private class fflib_QueryFactoryTest {
        	//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(relationship, true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -350,8 +350,8 @@ private class fflib_QueryFactoryTest {
        	//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(relationship).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -370,7 +370,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;   
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -381,8 +381,8 @@ private class fflib_QueryFactoryTest {
 		//explicitly assert object accessibility when creating the subselect
 		qf.subselectQuery(Task.SObjectType, true).selectField('Id').selectField('Subject').setCondition(' IsDeleted = false ');
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(
+		Assert.isTrue(queries != null);
+		Assert.isTrue(
 				Pattern.matches('SELECT.*(SELECT.*FROM Tasks WHERE.*).*FROM Contact WHERE.*', qf.toSOQL()),
 				'Incorrect returned query'
 		);
@@ -402,15 +402,15 @@ private class fflib_QueryFactoryTest {
                 relationship = childRow;
             }
         }
-        System.assert(qf.getSubselectQueries() == null);
+        Assert.isTrue(qf.getSubselectQueries() == null);
 		fflib_QueryFactory childQf = qf.subselectQuery(Task.SObjectType);
 		childQf.assertIsAccessible();
 		childQf.setEnforceFLS(true);
 		childQf.selectField('Id');
 		fflib_QueryFactory childQf2 = qf.subselectQuery(Task.SObjectType);
 		List<fflib_QueryFactory> queries = qf.getSubselectQueries();
-		System.assert(queries != null);
-		System.assert(queries.size() == 1);
+		Assert.isTrue(queries != null);
+		Assert.isTrue(queries.size() == 1);
 	}
 
 	@isTest
@@ -429,7 +429,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -450,7 +450,7 @@ private class fflib_QueryFactoryTest {
 		} catch (fflib_QueryFactory.InvalidSubqueryRelationshipException ex) {
 			e = ex;   
 		}	
-		System.assertNotEquals(e, null);
+		Assert.areNotEqual(e, null);
 	}
 
 	@isTest
@@ -472,9 +472,9 @@ private class fflib_QueryFactoryTest {
 		  .addOrdering(Contact.CreatedDate,fflib_QueryFactory.SortOrder.DESCENDING, true);
 		Set<String> fields = qf.getSelectedFields();
 		fflib_QueryFactory.Ordering ordering = new fflib_QueryFactory.Ordering('Contact','name',fflib_QueryFactory.SortOrder.ASCENDING);
-		System.assertEquals('Name',ordering.getField());
+		Assert.areEqual('Name',ordering.getField());
 
-		System.assertEquals(new Set<String>{
+		Assert.areEqual(new Set<String>{
 			'CreatedBy.Name',
 			'LastModifiedById',
 			'LastModifiedDate',
@@ -483,7 +483,7 @@ private class fflib_QueryFactoryTest {
 			'FirstName'},
 			fields);
 
-		System.assert(qf.toSOQL().containsIgnoreCase('NULLS LAST'));
+		Assert.isTrue(qf.toSOQL().containsIgnoreCase('NULLS LAST'));
 	}
 
 	@isTest
@@ -500,7 +500,7 @@ private class fflib_QueryFactoryTest {
 				} catch (fflib_SecurityUtils.CrudException e) {
 					excThrown = true;
 				}	
-				System.assert(excThrown);
+				Assert.isTrue(excThrown);
 			}	
 		}	
 	}  
@@ -520,7 +520,7 @@ private class fflib_QueryFactoryTest {
 				} catch (fflib_SecurityUtils.FlsException e) {
 					excThrown = true;
 				}	
-				System.assert(excThrown);
+				Assert.isTrue(excThrown);
 			}	
 		}	
 	}
@@ -530,7 +530,7 @@ private class fflib_QueryFactoryTest {
 		fflib_QueryFactory qf = new fflib_QueryFactory(Contact.SObjectType);
 		qf.assertIsAccessible().setEnforceFLS(true).setCondition( 'name like \'%test%\'' ).addOrdering('CreatedDate',fflib_QueryFactory.SortOrder.DESCENDING);
 		String query = qf.toSOQL();
-		System.assert(query.containsIgnoreCase('SELECT Id FROM Contact'),'Expected \'SELECT Id FROM Contact\' in the SOQL, found: ' + query);
+		Assert.isTrue(query.containsIgnoreCase('SELECT Id FROM Contact'),'Expected \'SELECT Id FROM Contact\' in the SOQL, found: ' + query);
 	}  
 
 	@isTest
@@ -551,9 +551,9 @@ private class fflib_QueryFactoryTest {
 			'SELECT CreatedBy.ManagerId, CreatedBy.Name, '
 			+'FirstName, Id, LastModifiedBy.Email, LastName '
 			+'FROM User';
-		System.assertEquals(qf1.toSOQL(), qf2.toSOQL());
-		System.assertEquals(expectedQuery, qf1.toSOQL());
-		System.assertEquals(expectedQuery, qf2.toSOQL());
+		Assert.areEqual(qf1.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(expectedQuery, qf1.toSOQL());
+		Assert.areEqual(expectedQuery, qf2.toSOQL());
 	}
 
 	@isTest
@@ -568,12 +568,12 @@ private class fflib_QueryFactoryTest {
 
 		fflib_QueryFactory qf2 = qf.deepClone();
 
-		System.assertEquals(qf2, qf);
+		Assert.areEqual(qf2, qf);
 
-		System.assertEquals(qf.getLimit(), qf2.getLimit());
-		System.assertEquals(qf.getCondition(), qf2.getCondition());
-		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
-		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
+		Assert.areEqual(qf.getLimit(), qf2.getLimit());
+		Assert.areEqual(qf.getCondition(), qf2.getCondition());
+		Assert.areEqual(qf.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(qf.getOrderings(), qf2.getOrderings());
 	}
 
 	@isTest
@@ -590,13 +590,13 @@ private class fflib_QueryFactoryTest {
 
 		fflib_QueryFactory qf2 = qf.deepClone();
 
-		System.assertEquals(qf, qf2);
+		Assert.areEqual(qf, qf2);
 
-		System.assertEquals(qf.getLimit(), qf2.getLimit());
-		System.assertEquals(qf.getCondition(), qf2.getCondition());
-		System.assertEquals(qf.toSOQL(), qf2.toSOQL());
-		System.assertEquals(qf.getOrderings(), qf2.getOrderings());
-		System.assertEquals(qf.getSubselectQueries(), qf2.getSubselectQueries());
+		Assert.areEqual(qf.getLimit(), qf2.getLimit());
+		Assert.areEqual(qf.getCondition(), qf2.getCondition());
+		Assert.areEqual(qf.toSOQL(), qf2.toSOQL());
+		Assert.areEqual(qf.getOrderings(), qf2.getOrderings());
+		Assert.areEqual(qf.getSubselectQueries(), qf2.getSubselectQueries());
 	}
 
 	@isTest
@@ -619,27 +619,27 @@ private class fflib_QueryFactoryTest {
 
 		qf2.getOrderings().remove(0);
 
-		System.assertEquals(10, qf.getLimit());
-		System.assertEquals(200, qf2.getLimit());
+		Assert.areEqual(10, qf.getLimit());
+		Assert.areEqual(200, qf2.getLimit());
 
-		System.assertEquals('id=12345', qf.getCondition());
-		System.assertEquals('id=54321', qf2.getCondition());
+		Assert.areEqual('id=12345', qf.getCondition());
+		Assert.areEqual('id=54321', qf2.getCondition());
 
 		String query = qf.toSOQL();
 		String query2 = qf2.toSOQL();
 
-		System.assert(query.containsIgnoreCase('Fax') == false);
-		System.assert(query.containsIgnoreCase('Description'));
-		System.assert(query2.containsIgnoreCase('Description'));
-		System.assert(query2.containsIgnoreCase('Fax'));
+		Assert.isTrue(query.containsIgnoreCase('Fax') == false);
+		Assert.isTrue(query.containsIgnoreCase('Description'));
+		Assert.isTrue(query2.containsIgnoreCase('Description'));
+		Assert.isTrue(query2.containsIgnoreCase('Fax'));
 
-		System.assertEquals(2, qf.getOrderings().size());
-		System.assertEquals('Name', qf.getOrderings()[0].getField() );
-		System.assertEquals(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[1].getDirection());
+		Assert.areEqual(2, qf.getOrderings().size());
+		Assert.areEqual('Name', qf.getOrderings()[0].getField() );
+		Assert.areEqual(fflib_QueryFactory.SortOrder.DESCENDING, qf.getOrderings()[1].getDirection());
 
-		System.assertEquals(2, qf2.getOrderings().size());
-		System.assertEquals('Fax', qf2.getOrderings()[1].getField());
-		System.assertEquals(fflib_QueryFactory.SortOrder.ASCENDING, qf2.getOrderings()[1].getDirection());
+		Assert.areEqual(2, qf2.getOrderings().size());
+		Assert.areEqual('Fax', qf2.getOrderings()[1].getField());
+		Assert.areEqual(fflib_QueryFactory.SortOrder.ASCENDING, qf2.getOrderings()[1].getDirection());
 
 	}
 
@@ -658,11 +658,11 @@ private class fflib_QueryFactoryTest {
 
 		subquery2_0.addOrdering(new fflib_QueryFactory.Ordering('Contact','Name',fflib_QueryFactory.SortOrder.ASCENDING));
 
-		System.assert(subqueries.size() == 1);
-		System.assert(subqueries2.size() == 2);
+		Assert.isTrue(subqueries.size() == 1);
+		Assert.isTrue(subqueries2.size() == 2);
 
-		System.assert(qf.getSubselectQueries().get(0).getOrderings().size() == 0);
-		System.assert(qf2.getSubselectQueries().get(0).getOrderings().size() == 1);
+		Assert.isTrue(qf.getSubselectQueries().get(0).getOrderings().size() == 0);
+		Assert.isTrue(qf2.getSubselectQueries().get(0).getOrderings().size() == 1);
 	}
 	
 	@isTest
@@ -690,7 +690,7 @@ private class fflib_QueryFactoryTest {
 		String actualSoql = qf.toSOQL();
 
 		//Then		
-		System.assertNotEquals(orderedQuery, actualSoql);
+		Assert.areNotEqual(orderedQuery, actualSoql);
 	}
 
 	@isTest
@@ -709,7 +709,7 @@ private class fflib_QueryFactoryTest {
 		String actualSoql = qf.toSOQL();
 
 		//Then		
-		System.assertEquals(allRowsQuery, actualSoql);
+		Assert.areEqual(allRowsQuery, actualSoql);
 	}
 
 	public static User createTestUser_noAccess(){
@@ -749,5 +749,21 @@ private class fflib_QueryFactoryTest {
 			return null;
 		}	
 		return usr;	
+	}
+
+	@IsTest
+	static void whenWithUserModeIsCalledFLSEnforcementIsUserMode() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+
+		qf.withUserMode();
+		Assert.areEqual(fflib_QueryFactory.FLSEnforcement.USER_MODE, qf.getFLSEnforcement());
+	}
+
+	@IsTest
+	static void whenWithSystemModeIsCalledFLSEnforcementIsSystemMode() {
+		fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);
+
+		qf.withSystemMode();
+		Assert.areEqual(fflib_QueryFactory.FLSEnforcement.SYSTEM_MODE, qf.getFLSEnforcement());
 	}
 }

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -35,8 +35,8 @@ private with sharing class fflib_SObjectSelectorTest
 	static testMethod void testGetSObjectName()
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
-		system.assertEquals(null, selector.getSObjectFieldSetList());
-		system.assertEquals('Account',selector.getSObjectName());
+		Assert.areEqual(null, selector.getSObjectFieldSetList());
+		Assert.areEqual('Account',selector.getSObjectName());
 	}
 	
 	static testMethod void testSelectSObjectsById()
@@ -55,13 +55,13 @@ private with sharing class fflib_SObjectSelectorTest
 		List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);		
 		Test.stopTest();
 		
-		system.assertEquals(2,result.size());
-		system.assertEquals('TestAccount2',result[0].Name);
-		system.assertEquals('A2',result[0].AccountNumber);
-		system.assertEquals(12345.67,result[0].AnnualRevenue);
-		system.assertEquals('TestAccount1',result[1].Name);
-		system.assertEquals('A1',result[1].AccountNumber);
-		system.assertEquals(76543.21,result[1].AnnualRevenue);
+		Assert.areEqual(2,result.size());
+		Assert.areEqual('TestAccount2',result[0].Name);
+		Assert.areEqual('A2',result[0].AccountNumber);
+		Assert.areEqual(12345.67,result[0].AnnualRevenue);
+		Assert.areEqual('TestAccount1',result[1].Name);
+		Assert.areEqual('A1',result[1].AccountNumber);
+		Assert.areEqual(76543.21,result[1].AnnualRevenue);
 	}
 
 	static testMethod void testQueryLocatorById()
@@ -81,17 +81,17 @@ private with sharing class fflib_SObjectSelectorTest
 		System.Iterator<SObject> iteratorResult = result.iterator();
 		Test.stopTest();		
 
-		System.assert(true, iteratorResult.hasNext());
+		Assert.isTrue(true, String.valueOf(iteratorResult.hasNext()));
 		Account account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount2',account.Name);
-		system.assertEquals('A2',account.AccountNumber);
-		system.assertEquals(12345.67,account.AnnualRevenue);				
-		System.assert(true, iteratorResult.hasNext());
+		Assert.areEqual('TestAccount2',account.Name);
+		Assert.areEqual('A2',account.AccountNumber);
+		Assert.areEqual(12345.67,account.AnnualRevenue);
+		Assert.isTrue(true, String.valueOf(iteratorResult.hasNext()));
 		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount1',account.Name);
-		system.assertEquals('A1',account.AccountNumber);
-		system.assertEquals(76543.21,account.AnnualRevenue);				
-		System.assertEquals(false, iteratorResult.hasNext());
+		Assert.areEqual('TestAccount1',account.Name);
+		Assert.areEqual('A1',account.AccountNumber);
+		Assert.areEqual(76543.21,account.AnnualRevenue);
+		Assert.areEqual(false, iteratorResult.hasNext());
 	}
 	
 	static testMethod void testAssertIsAccessible()
@@ -114,11 +114,11 @@ private with sharing class fflib_SObjectSelectorTest
 			try
 			{
 				List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);
-				System.assert(false,'Expected exception was not thrown');
+				Assert.isTrue(false,'Expected exception was not thrown');
 			}
 			catch(fflib_SObjectDomain.DomainException e)
 			{
-				System.assertEquals('Permission to access an Account denied.',e.getMessage());
+				Assert.areEqual('Permission to access an Account denied.',e.getMessage());
 			}
 		}
 	}
@@ -146,7 +146,7 @@ private with sharing class fflib_SObjectSelectorTest
 			}
 			catch(fflib_SObjectDomain.DomainException e)
 			{
-				System.assert(false,'Did not expect an exception to be thrown');
+				Assert.isTrue(false,'Did not expect an exception to be thrown');
 			}
 		}
 	}
@@ -157,8 +157,8 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = selector.newQueryFactory().toSOQL();
 		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
-		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
-		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
+		Assert.isTrue(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.areEqual(1, m.groupCount(), 'Unexpected number of groups captured.');
 		String fieldListString = m.group(1);
 		assertFieldListString(fieldListString, null);
 	}
@@ -169,8 +169,8 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = selector.newQueryFactory().toSOQL();
 		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name ASC NULLS FIRST ');
 		Matcher m = p.matcher(soql);
-		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
-		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
+		Assert.isTrue(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.areEqual(1, m.groupCount(), 'Unexpected number of groups captured.');
 		String fieldListString = m.group(1);
 		assertFieldListString(fieldListString, null);
 	}
@@ -178,32 +178,32 @@ private with sharing class fflib_SObjectSelectorTest
 	static testMethod void testDefaultConfig()
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
-		System.assertEquals(false, selector.isEnforcingFLS());
-		System.assertEquals(true, selector.isEnforcingCRUD());
-		System.assertEquals(false, selector.isIncludeFieldSetFields());
-		System.assertEquals(fflib_SObjectSelector.DataAccess.LEGACY, selector.getDataAccess());
+		Assert.areEqual(false, selector.isEnforcingFLS());
+		Assert.areEqual(true, selector.isEnforcingCRUD());
+		Assert.areEqual(false, selector.isIncludeFieldSetFields());
+		Assert.areEqual(fflib_SObjectSelector.DataAccess.LEGACY, selector.getDataAccess());
 		
-		System.assertEquals('Account', selector.getSObjectName());
-		System.assertEquals(Account.SObjectType, selector.getSObjectType2());
+		Assert.areEqual('Account', selector.getSObjectName());
+		Assert.areEqual(Account.SObjectType, selector.getSObjectType2());
 	}
 	
 	private static void assertFieldListString(String fieldListString, String prefix) {
 		String prefixString = (!String.isBlank(prefix)) ? prefix + '.' : '';
 		List<String> fieldList = fieldListString.split(',{1}\\s?');
-		System.assertEquals(UserInfo.isMultiCurrencyOrganization() ? 5 : 4, fieldList.size()); 
+		Assert.areEqual(UserInfo.isMultiCurrencyOrganization() ? 5 : 4, fieldList.size());
 		Set<String> fieldSet = new Set<String>();
 		fieldSet.addAll(fieldList);
 		String expected = prefixString + 'AccountNumber';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'AnnualRevenue';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'Id';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		expected = prefixString + 'Name';
-		System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+		Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		if (UserInfo.isMultiCurrencyOrganization()) {
 			expected = prefixString + 'CurrencyIsoCode';
-			System.assert(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
+			Assert.isTrue(fieldSet.contains(expected), expected + ' missing from field list string: ' + fieldListString);
 		}
 	}
 	
@@ -230,7 +230,7 @@ private with sharing class fflib_SObjectSelectorTest
 		soqlMatcher.matches();
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	// Test case of ordering with NULLS LAST option passed into the ordering method
@@ -254,7 +254,7 @@ private with sharing class fflib_SObjectSelectorTest
 		// Assert that the
 		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
+		Assert.isTrue(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
 
 	@IsTest
@@ -276,10 +276,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -301,10 +301,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -326,10 +326,10 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
+		Assert.isTrue(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -349,7 +349,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		List<String> actualSelectFields = fieldListString.deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	@IsTest
@@ -368,7 +368,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		List<String> actualSelectFields = fieldListString.deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 
 	}
 
@@ -446,7 +446,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String expected = 'SELECT name, id, amount, closedate, account\\.name, account\\.billingpostalcode(.*)FROM Opportunity WITH SYSTEM_MODE ORDER BY Name ASC NULLS FIRST ';
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
+		Assert.isTrue(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
 	}
 
 	@IsTest
@@ -458,7 +458,71 @@ private with sharing class fflib_SObjectSelectorTest
 		String expected = 'SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY Name ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY Name ASC NULLS FIRST ';
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
-		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
+		Assert.isTrue(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
+	}
+
+	@IsTest
+	static void whenWithUserModeIsCalledDataAccessIsUserMode() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withUserMode();
+		Assert.areEqual(fflib_SObjectSelector.DataAccess.USER_MODE, selector.getDataAccess());
+	}
+
+	@IsTest
+	static void whenWithSystemModeIsCalledThenDataAccessIsSystemMode() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withSystemMode();
+		Assert.areEqual(fflib_SObjectSelector.DataAccess.SYSTEM_MODE, selector.getDataAccess());
+	}
+
+	@IsTest
+	static void whenDataAccessIsUserModeThenIsEnforcingFLSIsTrue() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withUserMode();
+		Assert.isTrue(selector.isEnforcingFLS());
+	}
+
+	@IsTest
+	static void whenDataAccessIsUserModeThenIsEnforcingCRUDIsTrue() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withUserMode();
+		Assert.isTrue(selector.isEnforcingCRUD());
+	}
+
+	@IsTest
+	static void whenDataAccessIsSystemModeThenIsEnforcingFLSIsFalse() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withSystemMode();
+		Assert.isFalse(selector.isEnforcingFLS());
+	}
+
+	@IsTest
+	static void whenDataAccessIsSystemModeThenIsEnforcingCRUDIsFalse() {
+		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
+
+		selector.withSystemMode();
+		Assert.isFalse(selector.isEnforcingCRUD());
+	}
+
+	@IsTest
+	static void whenDataAccessIsNotLegacyAndEnforceFLSIsCalledThenDataAccessIsSetToLegacy() {
+		AccessLevelAccountSelector selector = new AccessLevelAccountSelector(fflib_SObjectSelector.DataAccess.USER_MODE);
+
+		selector.enforceFLS();
+		Assert.areEqual(fflib_SObjectSelector.DataAccess.LEGACY, selector.getDataAccess());
+	}
+
+	@IsTest
+	static void whenDataAccessIsNotLegacyAndEnforceFLSIsCalledThenIsEnforcingCrudReturnsTrue() {
+		AccessLevelAccountSelector selector = new AccessLevelAccountSelector(fflib_SObjectSelector.DataAccess.USER_MODE);
+
+		selector.enforceFLS();
+		Assert.isTrue(selector.isEnforcingCRUD());
 	}
 
 
@@ -677,7 +741,7 @@ private with sharing class fflib_SObjectSelectorTest
 		soqlMatcher.matches();
 
 		List<String> actualSelectFields = soqlMatcher.group(1).deleteWhiteSpace().split(',');
-		System.assertEquals(expectedSelectFields, new Set<String>(actualSelectFields));
+		Assert.areEqual(expectedSelectFields, new Set<String>(actualSelectFields));
 	}
 
 	private class Testfflib_CampaignMemberSelector extends fflib_SObjectSelector {


### PR DESCRIPTION
Add `withUserMode()` and `withSystemMode()` to `fflib_SObjectSelector` and `fflib_QueryFactory`

## fflib_QueryFactory

### Specify `WITH USER_MODE`
```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.withUserMode();
qf.getFLSEnforcement(); // USER_MODE

// OR

qf.setFLSEnforcement(fflib_QueryFactory.FLSEnforcement.USER_MODE);
qf.getFLSEnforcement(); // USER_MODE
```

### Specify `WITH SYSTEM_MODE`
Salesforce uses `SYSTEM_MODE` as the default operation mode when not specified in the query.  `withSystemMode()` allows users to make their queries explicit if desired.

```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.withSystemMode();
qf.getFLSEnforcement(); // SYSTEM_MODE

// OR

qf.setFLSEnforcement(fflib_QueryFactory.FLSEnforcement.SYSTEM_MODE);
qf.getFLSEnforcement(); // SYSTEM_MODE
```

### Switch back to `LEGACY` or `NONE`

```java
fflib_QueryFactory qf = new fflib_QueryFactory(Account.SObjectType);

qf.withSystemMode();
qf.getFLSEnforcement(); // SYSTEM_MODE

qf.setEnforceFLS(true);
qf.getFLSEnforcement(); // LEGACY

// OR

qf.setEnforceFLS(FLSEnforcement.LEGACY);

// OR

qf.setEnforceFLS(false);
qf.getFLSEnforcement(); // NONE

// OR

qf.setEnforceFLS(FLSEnforcement.NONE);
```

## fflib_SObjectSelector

`isEnforcingFLS()` and `isEnforcingCRUD()` now consider the `DataAccess` to determine their result instead of directly returning the values of `m_enforceFLS` and `m_enforceCRUD`.  This allows the user to get the correct state from the methods, regardless if they are using legacy enforcement or one of the new operation modes.

### Specify `USER_MODE`

```java
AccountSelector selector = new AccountSelector();

selector.withUserMode();

selector.isEnforcingCRUD(); // true
selector.isEnforcingFLS(); // true
```

### Specify `SYSTEM_MODE`

```java
AccountSelector selector = new AccountSelector();

selector.withSystemMode();

selector.isEnforcingCRUD(); // false
selector.isEnforcingFLS(); // false
```

### Switch back to `LEGACY`

```java
AccountSelector selector = new AccountSelector();

selector.withSystemMode();

selector.isEnforcingCRUD(); // false
selector.isEnforcingFLS(); // false
selector.getDataAccess(); // SYSTEM_MODE

selector.enforceFLS();
selector.isEnforcingCRUD(): // true
selector.isEnforcingFLS(); // true
selector.getDataAccess(); // LEGACY

// OR

selector.setDataAccess(fflib_SObjectSelector.DataAccess.LEGACY);
selector.getDataAccess(); // LEGACY
```

## Add

### fflib_QueryFactory

- void withUserMode()
- void withSystemMode()
- fflib_QueryFactory.FLSEnforcement getFLSEnforcement()
- Boolean isEnforcingFLS();

### fflib_SObjectSelector

- void withUserMode()
- void withSystemMode()

## Change

### fflib_QueryFactoryTest

- Replace System asserts with new Assert class

### fflib_SObjectSelector

- Update `enforceFLS()` to set `m_dataAccess` to `LEGACY`
- Update `setDataAccess()` to revert `m_enforceCRUD` to true when `m_dataAccess` is `LEGACY`
- Update `isEnforcingFLS()` to return true when `m_dataAccess` is set to `USER_MODE`
- Update `isEnforcingCRUD()` to return true when `m_dataAccess` is set to `USER_MODE`

### fflib_SObjectSelectorTest

- Replace System asserts with new Assert class

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/435)
<!-- Reviewable:end -->
