### PR TITLE
Bugfix For Issue: 451 - Allow for either Name or CreatedDate as order by.

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -27,6 +27,10 @@
 @IsTest
 private with sharing class fflib_SObjectSelectorTest 
 {
+	//Get the correct sort field depending on sortable status of Name field
+	static String getDefaultSortField(DescribeSObjectResult sobjDesc) {
+		return sobjDesc.fields.getMap().get('name').getDescribe().isSortable() ? 'Name' : 'CreatedDate';
+	} 
 	@TestSetup
 	static void testSetup(){
 		fflib_SecurityUtilsTest.testSetup();
@@ -167,7 +171,8 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelectorDefaultSorting selector = new Testfflib_SObjectSelectorDefaultSorting(false);
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY (?:Name|CreatedDate) ASC NULLS FIRST ');
+		Pattern p = Pattern.compile(String.format('SELECT (.*) FROM Account ORDER BY {0} ASC NULLS FIRST ',
+			new List<String>{getDefaultSortField(SObjectType.Account)}));
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -443,7 +448,8 @@ private with sharing class fflib_SObjectSelectorTest
 
 		String soql = sel.createSelectAllWithAccountSOQL();
 
-		String expected = 'SELECT name, id, amount, closedate, account\\.name, account\\.billingpostalcode(.*)FROM Opportunity WITH SYSTEM_MODE ORDER BY Name ASC NULLS FIRST ';
+		String expected = String.format('SELECT name, id, amount, closedate, account\\.name, account\\.billingpostalcode(.*)FROM Opportunity WITH SYSTEM_MODE ORDER BY {0} ASC NULLS FIRST ',
+			new List<String>{getDefaultSortField(SObjectType.Opportunity)});
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
@@ -455,7 +461,8 @@ private with sharing class fflib_SObjectSelectorTest
 
 		String soql = sel.createSelectAccountWithOpportunitiesSOQL();
 
-		String expected = 'SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY Name ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY (?:Name|CreatedDate) ASC NULLS FIRST ';
+		String expected = String.format('SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {1} ASC NULLS FIRST ',
+			new List<String>{getDefaultSortField(SObjectType.Opportunity),getDefaultSortField(SObjectType.Account)});
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -167,7 +167,7 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelectorDefaultSorting selector = new Testfflib_SObjectSelectorDefaultSorting(false);
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name ASC NULLS FIRST ');
+		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY (?:Name|CreatedDate) ASC NULLS FIRST ');
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -455,7 +455,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		String soql = sel.createSelectAccountWithOpportunitiesSOQL();
 
-		String expected = 'SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY Name ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY Name ASC NULLS FIRST ';
+		String expected = 'SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY Name ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY (?:Name|CreatedDate) ASC NULLS FIRST ';
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -44,12 +44,23 @@ private with sharing class fflib_SObjectSelectorTest
 	}
 	
 	static testMethod void testSelectSObjectsById()
-	{
-		// Inserting in reverse order so that we can test the order by of select 
+	{ 
 		List<Account> accountList = new List<Account> {
-			new Account(Name='TestAccount2',AccountNumber='A2',AnnualRevenue=12345.67),
-			new Account(Name='TestAccount1',AccountNumber='A1',AnnualRevenue=76543.21) };		
-		insert accountList;		
+			new Account(Name='TestAccount1',AccountNumber='A2',AnnualRevenue=null),
+			new Account(Name='TestAccount2',AccountNumber='A1',AnnualRevenue=76543.21),
+			new Account(Name='TestAccount3',AccountNumber='A3',AnnualRevenue=76543.21),
+			new Account(Name='TestAccount4',AccountNumber='A4',AnnualRevenue=12345.21) };		
+		insert accountList;
+
+		final DateTime TODAYS_DATE = System.now();
+		final DateTime YESTERDAYS_DATE = System.now().addDays(-1);
+		
+		//Set dates to allow sorting by created date as well as annualrevenue NULLS LAST
+		Test.setCreatedDate(accountList[0].Id,TODAYS_DATE);
+		Test.setCreatedDate(accountList[1].Id,TODAYS_DATE);
+		Test.setCreatedDate(accountList[2].Id,YESTERDAYS_DATE);
+		Test.setCreatedDate(accountList[3].Id,YESTERDAYS_DATE);
+		
 		Set<Id> idSet = new Set<Id>();
 		for(Account item : accountList)
 			idSet.add(item.Id);
@@ -59,22 +70,40 @@ private with sharing class fflib_SObjectSelectorTest
 		List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);		
 		Test.stopTest();
 		
-		system.assertEquals(2,result.size());
+		system.assertEquals(4,result.size());
 		system.assertEquals('TestAccount2',result[0].Name);
-		system.assertEquals('A2',result[0].AccountNumber);
-		system.assertEquals(12345.67,result[0].AnnualRevenue);
+		system.assertEquals('A1',result[0].AccountNumber);
+		system.assertEquals(76543.21,result[0].AnnualRevenue);
 		system.assertEquals('TestAccount1',result[1].Name);
-		system.assertEquals('A1',result[1].AccountNumber);
-		system.assertEquals(76543.21,result[1].AnnualRevenue);
+		system.assertEquals('A2',result[1].AccountNumber);
+		system.assertEquals(null,result[1].AnnualRevenue);
+		system.assertEquals('TestAccount4',result[2].Name);
+		system.assertEquals('A4',result[2].AccountNumber);
+		system.assertEquals(12345.21,result[2].AnnualRevenue);
+		system.assertEquals('TestAccount3',result[3].Name);
+		system.assertEquals('A3',result[3].AccountNumber);
+		system.assertEquals(76543.21,result[3].AnnualRevenue);
+
 	}
 
 	static testMethod void testQueryLocatorById()
 	{
-		// Inserting in reverse order so that we can test the order by of select 
 		List<Account> accountList = new List<Account> {
-			new Account(Name='TestAccount2',AccountNumber='A2',AnnualRevenue=12345.67),
-			new Account(Name='TestAccount1',AccountNumber='A1',AnnualRevenue=76543.21) };		
+			new Account(Name='TestAccount1',AccountNumber='A2',AnnualRevenue=null),
+			new Account(Name='TestAccount2',AccountNumber='A1',AnnualRevenue=76543.21),
+			new Account(Name='TestAccount3',AccountNumber='A3',AnnualRevenue=76543.21),
+			new Account(Name='TestAccount4',AccountNumber='A4',AnnualRevenue=12345.21) };		
 		insert accountList;		
+
+		final DateTime TODAYS_DATE = System.now();
+		final DateTime YESTERDAYS_DATE = System.now().addDays(-1);
+		
+		//Set dates to allow sorting by created date as well as annualrevenue NULLS LAST
+		Test.setCreatedDate(accountList[0].Id,TODAYS_DATE);
+		Test.setCreatedDate(accountList[1].Id,TODAYS_DATE);
+		Test.setCreatedDate(accountList[2].Id,YESTERDAYS_DATE);
+		Test.setCreatedDate(accountList[3].Id,YESTERDAYS_DATE);
+
 		Set<Id> idSet = new Set<Id>();
 		for(Account item : accountList)
 			idSet.add(item.Id);
@@ -88,14 +117,26 @@ private with sharing class fflib_SObjectSelectorTest
 		System.assert(true, iteratorResult.hasNext());
 		Account account = (Account) iteratorResult.next();
 		system.assertEquals('TestAccount2',account.Name);
-		system.assertEquals('A2',account.AccountNumber);
-		system.assertEquals(12345.67,account.AnnualRevenue);				
-		System.assert(true, iteratorResult.hasNext());
-		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount1',account.Name);
 		system.assertEquals('A1',account.AccountNumber);
 		system.assertEquals(76543.21,account.AnnualRevenue);				
+		System.assertEquals(true, iteratorResult.hasNext());
+		account = (Account) iteratorResult.next();
+		system.assertEquals('TestAccount1',account.Name);
+		system.assertEquals('A2',account.AccountNumber);
+		system.assertEquals(null,account.AnnualRevenue);				
+		System.assertEquals(true, iteratorResult.hasNext());
+		account = (Account) iteratorResult.next();
+		system.assertEquals('TestAccount4',account.Name);
+		system.assertEquals('A4',account.AccountNumber);
+		system.assertEquals(12345.21,account.AnnualRevenue);				
+		System.assert(true, iteratorResult.hasNext());
+		account = (Account) iteratorResult.next();
+		system.assertEquals('TestAccount3',account.Name);
+		system.assertEquals('A3',account.AccountNumber);
+		system.assertEquals(76543.21,account.AnnualRevenue);				
 		System.assertEquals(false, iteratorResult.hasNext());
+
+	
 	}
 	
 	static testMethod void testAssertIsAccessible()
@@ -159,7 +200,7 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -230,7 +271,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		//Then
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		soqlMatcher.matches();
 
@@ -257,7 +298,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		// Assert that the
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY Name DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
@@ -498,7 +539,7 @@ private with sharing class fflib_SObjectSelectorTest
 		
 		public override String getOrderBy()
 		{
-			return 'Name DESC, AnnualRevenue ASC NULLS LAST';
+			return 'CreatedDate DESC, AnnualRevenue ASC NULLS LAST';
 		}
 	}
 	

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -44,23 +44,12 @@ private with sharing class fflib_SObjectSelectorTest
 	}
 	
 	static testMethod void testSelectSObjectsById()
-	{ 
+	{
+		// Inserting in reverse order so that we can test the order by of select 
 		List<Account> accountList = new List<Account> {
-			new Account(Name='TestAccount1',AccountNumber='A2',AnnualRevenue=null),
-			new Account(Name='TestAccount2',AccountNumber='A1',AnnualRevenue=76543.21),
-			new Account(Name='TestAccount3',AccountNumber='A3',AnnualRevenue=76543.21),
-			new Account(Name='TestAccount4',AccountNumber='A4',AnnualRevenue=12345.21) };		
-		insert accountList;
-
-		final DateTime TODAYS_DATE = System.now();
-		final DateTime YESTERDAYS_DATE = System.now().addDays(-1);
-		
-		//Set dates to allow sorting by created date as well as annualrevenue NULLS LAST
-		Test.setCreatedDate(accountList[0].Id,TODAYS_DATE);
-		Test.setCreatedDate(accountList[1].Id,TODAYS_DATE);
-		Test.setCreatedDate(accountList[2].Id,YESTERDAYS_DATE);
-		Test.setCreatedDate(accountList[3].Id,YESTERDAYS_DATE);
-		
+			new Account(Name='TestAccount2',AccountNumber='A2',AnnualRevenue=12345.67),
+			new Account(Name='TestAccount1',AccountNumber='A1',AnnualRevenue=76543.21) };		
+		insert accountList;		
 		Set<Id> idSet = new Set<Id>();
 		for(Account item : accountList)
 			idSet.add(item.Id);
@@ -70,40 +59,22 @@ private with sharing class fflib_SObjectSelectorTest
 		List<Account> result = (List<Account>) selector.selectSObjectsById(idSet);		
 		Test.stopTest();
 		
-		system.assertEquals(4,result.size());
+		system.assertEquals(2,result.size());
 		system.assertEquals('TestAccount2',result[0].Name);
-		system.assertEquals('A1',result[0].AccountNumber);
-		system.assertEquals(76543.21,result[0].AnnualRevenue);
+		system.assertEquals('A2',result[0].AccountNumber);
+		system.assertEquals(12345.67,result[0].AnnualRevenue);
 		system.assertEquals('TestAccount1',result[1].Name);
-		system.assertEquals('A2',result[1].AccountNumber);
-		system.assertEquals(null,result[1].AnnualRevenue);
-		system.assertEquals('TestAccount4',result[2].Name);
-		system.assertEquals('A4',result[2].AccountNumber);
-		system.assertEquals(12345.21,result[2].AnnualRevenue);
-		system.assertEquals('TestAccount3',result[3].Name);
-		system.assertEquals('A3',result[3].AccountNumber);
-		system.assertEquals(76543.21,result[3].AnnualRevenue);
-
+		system.assertEquals('A1',result[1].AccountNumber);
+		system.assertEquals(76543.21,result[1].AnnualRevenue);
 	}
 
 	static testMethod void testQueryLocatorById()
 	{
+		// Inserting in reverse order so that we can test the order by of select 
 		List<Account> accountList = new List<Account> {
-			new Account(Name='TestAccount1',AccountNumber='A2',AnnualRevenue=null),
-			new Account(Name='TestAccount2',AccountNumber='A1',AnnualRevenue=76543.21),
-			new Account(Name='TestAccount3',AccountNumber='A3',AnnualRevenue=76543.21),
-			new Account(Name='TestAccount4',AccountNumber='A4',AnnualRevenue=12345.21) };		
+			new Account(Name='TestAccount2',AccountNumber='A2',AnnualRevenue=12345.67),
+			new Account(Name='TestAccount1',AccountNumber='A1',AnnualRevenue=76543.21) };		
 		insert accountList;		
-
-		final DateTime TODAYS_DATE = System.now();
-		final DateTime YESTERDAYS_DATE = System.now().addDays(-1);
-		
-		//Set dates to allow sorting by created date as well as annualrevenue NULLS LAST
-		Test.setCreatedDate(accountList[0].Id,TODAYS_DATE);
-		Test.setCreatedDate(accountList[1].Id,TODAYS_DATE);
-		Test.setCreatedDate(accountList[2].Id,YESTERDAYS_DATE);
-		Test.setCreatedDate(accountList[3].Id,YESTERDAYS_DATE);
-
 		Set<Id> idSet = new Set<Id>();
 		for(Account item : accountList)
 			idSet.add(item.Id);
@@ -113,30 +84,18 @@ private with sharing class fflib_SObjectSelectorTest
 		Database.QueryLocator result = selector.queryLocatorById(idSet);		
 		System.Iterator<SObject> iteratorResult = result.iterator();
 		Test.stopTest();		
-
+	
 		System.assert(true, iteratorResult.hasNext());
 		Account account = (Account) iteratorResult.next();
 		system.assertEquals('TestAccount2',account.Name);
-		system.assertEquals('A1',account.AccountNumber);
-		system.assertEquals(76543.21,account.AnnualRevenue);				
-		System.assertEquals(true, iteratorResult.hasNext());
-		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount1',account.Name);
 		system.assertEquals('A2',account.AccountNumber);
-		system.assertEquals(null,account.AnnualRevenue);				
-		System.assertEquals(true, iteratorResult.hasNext());
-		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount4',account.Name);
-		system.assertEquals('A4',account.AccountNumber);
-		system.assertEquals(12345.21,account.AnnualRevenue);				
+		system.assertEquals(12345.67,account.AnnualRevenue);				
 		System.assert(true, iteratorResult.hasNext());
 		account = (Account) iteratorResult.next();
-		system.assertEquals('TestAccount3',account.Name);
-		system.assertEquals('A3',account.AccountNumber);
+		system.assertEquals('TestAccount1',account.Name);
+		system.assertEquals('A1',account.AccountNumber);
 		system.assertEquals(76543.21,account.AnnualRevenue);				
 		System.assertEquals(false, iteratorResult.hasNext());
-
-	
 	}
 	
 	static testMethod void testAssertIsAccessible()
@@ -200,7 +159,7 @@ private with sharing class fflib_SObjectSelectorTest
 	{
 		Testfflib_SObjectSelector selector = new Testfflib_SObjectSelector();
 		String soql = selector.newQueryFactory().toSOQL();
-		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern p = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -271,7 +230,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		//Then
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		soqlMatcher.matches();
 
@@ -298,7 +257,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		// Assert that the
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY CreatedDate DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
+		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM Account ORDER BY AccountNumber DESC NULLS FIRST , AnnualRevenue ASC NULLS LAST ');
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		system.assert(soqlMatcher.matches(), 'The SOQL should have that expected.');
 	}
@@ -539,7 +498,7 @@ private with sharing class fflib_SObjectSelectorTest
 		
 		public override String getOrderBy()
 		{
-			return 'CreatedDate DESC, AnnualRevenue ASC NULLS LAST';
+			return 'AccountNumber DESC, AnnualRevenue ASC NULLS LAST';
 		}
 	}
 	

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -27,10 +27,6 @@
 @IsTest
 private with sharing class fflib_SObjectSelectorTest 
 {
-	//Get the correct sort field depending on sortable status of Name field
-	static String getDefaultSortField(DescribeSObjectResult sobjDesc) {
-		return sobjDesc.fields.getMap().get('name').getDescribe().isSortable() ? 'Name' : 'CreatedDate';
-	} 
 	@TestSetup
 	static void testSetup(){
 		fflib_SecurityUtilsTest.testSetup();
@@ -172,7 +168,7 @@ private with sharing class fflib_SObjectSelectorTest
 		Testfflib_SObjectSelectorDefaultSorting selector = new Testfflib_SObjectSelectorDefaultSorting(false);
 		String soql = selector.newQueryFactory().toSOQL();
 		Pattern p = Pattern.compile(String.format('SELECT (.*) FROM Account ORDER BY {0} ASC NULLS FIRST ',
-			new List<String>{getDefaultSortField(SObjectType.Account)}));
+			new List<String>{selector.getOrderBy()}));
 		Matcher m = p.matcher(soql);
 		System.assert(m.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 		System.assertEquals(1, m.groupCount(), 'Unexpected number of groups captured.');
@@ -304,7 +300,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		String soql = qf.toSOQL();
-		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
+		Pattern soqlPattern = Pattern.compile(String.format('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY {0} ASC NULLS FIRST \\) +FROM Account',new List<String>{selector.getOrderBy()}));
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
@@ -329,7 +325,8 @@ private with sharing class fflib_SObjectSelectorTest
 
 		//Then
 		String soql = qf.toSOQL();
-		Pattern soqlPattern = Pattern.compile('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY Name ASC NULLS FIRST \\) +FROM Account');
+		Pattern soqlPattern = Pattern.compile(String.format('SELECT Id, \\(SELECT (.*) FROM Users ORDER BY {0} ASC NULLS FIRST \\) +FROM Account',
+			new List<String>{selector.getOrderBy()}));
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(), 'Generated SOQL does not match expected pattern. Here is the generated SOQL: ' + soql);
 
@@ -449,7 +446,7 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = sel.createSelectAllWithAccountSOQL();
 
 		String expected = String.format('SELECT name, id, amount, closedate, account\\.name, account\\.billingpostalcode(.*)FROM Opportunity WITH SYSTEM_MODE ORDER BY {0} ASC NULLS FIRST ',
-			new List<String>{getDefaultSortField(SObjectType.Opportunity)});
+			new List<String>{sel.getOrderBy()});
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
@@ -461,8 +458,8 @@ private with sharing class fflib_SObjectSelectorTest
 
 		String soql = sel.createSelectAccountWithOpportunitiesSOQL();
 
-		String expected = String.format('SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {1} ASC NULLS FIRST ',
-			new List<String>{getDefaultSortField(SObjectType.Opportunity),getDefaultSortField(SObjectType.Account)});
+		String expected = String.format('SELECT name, id, annualrevenue, accountnumber,(.*)\\(SELECT name, id, amount, closedate FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {0} ASC NULLS FIRST ',
+			new List<String>{sel.getOrderBy()});
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
@@ -679,7 +676,8 @@ private with sharing class fflib_SObjectSelectorTest
 		String soql = qf.toSOQL();
 
 		//Then
-		Pattern soqlPattern = Pattern.compile('SELECT (.*) FROM CampaignMember ORDER BY CreatedDate ASC NULLS FIRST ');
+		Pattern soqlPattern = Pattern.compile(String.format('SELECT (.*) FROM CampaignMember ORDER BY {0} ASC NULLS FIRST ',
+		new List<String>{cmSelector.getOrderBy()}));
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		soqlMatcher.matches();
 
@@ -701,7 +699,8 @@ private with sharing class fflib_SObjectSelectorTest
 			expectedSelectFields.add('CurrencyIsoCode');
 		}
 
-		String expectedSOQL = 'SELECT ' + String.join(expectedSelectFields,', ') + ' FROM CampaignMember WITH SYSTEM_MODE ORDER BY CreatedDate ASC NULLS FIRST ';
+		String expectedSOQL = String.format('SELECT ' + String.join(expectedSelectFields,', ') + ' FROM CampaignMember WITH SYSTEM_MODE ORDER BY {0} ASC NULLS FIRST ',
+			new List<String>{cmSelector.getOrderBy()});
 
 		//When
 		String actualSOQL = qf.toSOQL();


### PR DESCRIPTION
#451 Harcoded Order by name fails with encrypted name.

Add fix so that selected fflib_SObjectSelectorTest  tests pass in orgs where platform encryption is enabled on Account.Name.

Existing tests
- toSOQL_When_SystemModeAndChildRelationship_Expect_WellFormedSOQL
- testSOQL_defaultSorting

Fail in orgs with encryption enabled on Account.Name

The following code in fflib_SObjectSelector means the order field varies from Name in  orgs where name isn't encrypted to CreatedDate where Name is encrypted.

```
 public virtual String getOrderBy()
 {
    if (m_orderBy == null)
    {
        Schema.SObjectField nameField = describeWrapper.getNameField();
        if (nameField != null && !nameField.getDescribe().isEncrypted())
        {
            m_orderBy = nameField.getDescribe().getName();
        }
        else
        {
            m_orderBy = DEFAULT_SORT_FIELD;
            try {
                if (describeWrapper.getField(m_orderBy) == null)
                {
                    m_orderBy = SF_ID_FIELD;
                }
            }
```

Updating the test regex to (?:Name|CreatedDate) ensures both  tests pass in orgs regardless of the encryption status of Account.Name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/452)
<!-- Reviewable:end -->
