### PR TITLE
Skip attempting to publish platform events when no platform events have been registered

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -109,6 +109,11 @@ public virtual class fflib_SObjectUnitOfWork
         }
         public virtual void eventPublish(List<SObject> objList)
         {
+            if (objList.isEmpty())
+            {
+                return;
+            }
+            
             EventBus.publish(objList);
         }
 		public virtual void emptyRecycleBin(List<SObject> objList)


### PR DESCRIPTION
- #455 describes a problem where calling `EventBus.publish()` via (doCommitWork() helper methods) and passing in an empty list of sObjects generates internal error logs
- This fix skips the `EventBus.publish()` call in the default `SimpleDML` implementation of the `IDML` interface when the supplied `List<sObject>` is empty, which mirrors the approach to used in `SimpleDML.emptyRecycleBin()`
- No unit tests have been added here. I am struggling to find any valuable way to test this scenario. Calling `EventBus.publish()` with an empty list doesn't generate any exception, doesn't return any `Database.SaveResult`, or contribute to any limits. The only impact I can see is the absence of internal error logs.

fixes apex-enterprise-patterns/fflib-apex-common#455

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/457)
<!-- Reviewable:end -->
