### PR TITLE
Allow overriding the configureQueryFactory

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -488,7 +488,7 @@ public abstract with sharing class fflib_SObjectSelector
     /**
      * Configures a QueryFactory instance according to the configuration of this selector
      **/        
-    private fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory,
+    protected virtual fflib_QueryFactory configureQueryFactory(fflib_QueryFactory queryFactory,
             Boolean assertCRUD,
             Boolean enforceFLS,
             Boolean includeSelectorFields,


### PR DESCRIPTION
I would like to write my own Selector factory that makes a few minor changes to how it communicates with the QueryFactory. 
To do that I would like to change the `configureQueryFactory` method into protected and virtual.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/464)
<!-- Reviewable:end -->
