### PR TITLE
UOW : Allow setting sharing mode for unit of work

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
@@ -30,6 +30,11 @@
 public interface fflib_ISObjectUnitOfWork
 {
     /**
+     * Explicitly sets sharing mode to be used when performing commitWork. When this is not set, it defaults to inherit the calling class.
+     * @param sharingMode Sharing mode to use during commitWork
+     */
+    void setSharingMode(fflib_SObjectUnitOfWork.SharingMode sharingMode);
+    /**
      * Register a newly created SObject instance to be inserted when commitWork is called
      *
      * @param record A newly created SObject instance to be inserted during commitWork

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -74,6 +74,7 @@ public virtual class fflib_SObjectUnitOfWork
     @TestVisible
     protected IEmailWork m_emailWork = new SendEmailWork();
 
+    @TestVisible
     protected IDML m_dml;
 
     private final Map<SharingMode, IDML> SHARING_MODE_MAP = new Map<SharingMode, IDML> {
@@ -163,6 +164,7 @@ public virtual class fflib_SObjectUnitOfWork
 		}
 	}
 
+    @TestVisible
     private virtual without sharing class WithoutSharingDML implements IDML {
         public virtual void dmlInsert(List<SObject> objList) {
             insert objList;
@@ -183,6 +185,7 @@ public virtual class fflib_SObjectUnitOfWork
         }
     }
 
+    @TestVisible
     private virtual with sharing class WithSharingDML implements IDML {
         public virtual void dmlInsert(List<SObject> objList) {
             insert objList;

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -76,6 +76,12 @@ public virtual class fflib_SObjectUnitOfWork
 
     protected IDML m_dml;
 
+    private final Map<SharingMode, IDML> SHARING_MODE_MAP = new Map<SharingMode, IDML> {
+        SharingMode.WITH => new WithSharingDML(),
+        SharingMode.WITHOUT => new WithoutSharingDML(),
+        SharingMode.INHERIT => new SimpleDML()
+    };
+
     /**
      * Interface describes work to be performed during the commitWork method
      **/
@@ -91,6 +97,12 @@ public virtual class fflib_SObjectUnitOfWork
         void dmlDelete(List<SObject> objList);
         void eventPublish(List<SObject> objList);
 	    void emptyRecycleBin(List<SObject> objList);
+    }
+
+    public enum SharingMode {
+        WITH,
+        WITHOUT,
+        INHERIT
     }
 
     public virtual class SimpleDML implements IDML

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -251,6 +251,15 @@ public virtual class fflib_SObjectUnitOfWork
     public virtual void onCommitWorkFinished(Boolean wasSuccessful) {}
 
     /**
+     * Sets sharing mode to be used when performing commitWork. When this is not set, it defaults to inherit the calling class.
+     *
+     * @param sharingMode Sharing mode to use during commitWork
+     */
+    public void setSharingMode(SharingMode sharingMode) {
+        this.m_dml = SHARING_MODE_MAP.get(sharingMode);
+    }
+
+    /**
      * Registers the type to be used for DML operations
      *
      * @param sObjectType - The type to register

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -151,6 +151,45 @@ public virtual class fflib_SObjectUnitOfWork
 		}
 	}
 
+    private virtual without sharing class WithoutSharingDML implements IDML {
+        public virtual void dmlInsert(List<SObject> objList) {
+            insert objList;
+        }
+        public virtual void dmlUpdate(List<SObject> objList) {
+            update objList;
+        }
+        public virtual void dmlDelete(List<SObject> objList) {
+            delete objList;
+        }
+        public virtual void eventPublish(List<SObject> objList) {
+            if(objList.isEmpty()) { return; }
+            EventBus.publish(objList);
+        }
+        public virtual void emptyRecycleBin(List<SObject> objList) {
+            if(objList.isEmpty()) { return; }
+            Database.emptyRecycleBin(objList);
+        }
+    }
+
+    private virtual with sharing class WithSharingDML implements IDML {
+        public virtual void dmlInsert(List<SObject> objList) {
+            insert objList;
+        }
+        public virtual void dmlUpdate(List<SObject> objList) {
+            update objList;
+        }
+        public virtual void dmlDelete(List<SObject> objList) {
+            delete objList;
+        }
+        public virtual void eventPublish(List<SObject> objList) {
+            if(objList.isEmpty()) { return; }
+            EventBus.publish(objList);
+        }
+        public virtual void emptyRecycleBin(List<SObject> objList) {
+            if(objList.isEmpty()) { return; }
+            Database.emptyRecycleBin(objList);
+        }
+    }
 
     /**
      * Constructs a new UnitOfWork to support work against the given object list

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -36,6 +36,18 @@ private with sharing class fflib_SObjectUnitOfWorkTest
             OpportunityLineItem.SObjectType };
 
     @IsTest
+    private static void testUnitOfWorkSetSharing() {
+        fflib_SObjectUnitOfWork unitOfWork = new fflib_SObjectUnitOfWork(MY_SOBJECTS);
+        Assert.isInstanceOfType(unitOfWork.m_dml, fflib_SObjectUnitOfWork.SimpleDML.class);
+
+        unitOfWork.setSharingMode(fflib_SObjectUnitOfWork.SharingMode.WITH);
+        Assert.isInstanceOfType(unitOfWork.m_dml, fflib_SObjectUnitOfWork.WithSharingDML.class);
+
+        unitOfWork.setSharingMode(fflib_SObjectUnitOfWork.SharingMode.WITHOUT);
+        Assert.isInstanceOfType(unitOfWork.m_dml, fflib_SObjectUnitOfWork.WithoutSharingDML.class);
+    }
+
+    @IsTest
     private static void testUnitOfWorkEmail()
     {
         String testRecordName = 'UoW Test Name 1';

--- a/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
+++ b/sfdx-source/apex-common/test/classes/mocks/fflib_SObjectMocks.cls
@@ -87,6 +87,11 @@ public class fflib_SObjectMocks
 			this.mocks = mocks;
 		}
 
+		public void setSharingMode(fflib_SObjectUnitOfWork.SharingMode sharingMode)
+		{
+			mocks.mockVoidMethod(this, 'setSharingMode', new List<Type> {fflib_SObjectUnitOfWork.SharingMode.class}, new List<Object> {sharingMode});
+		}
+
 		public void registerNew(SObject record)
 		{
 			mocks.mockVoidMethod(this, 'registerNew', new List<Type> {SObject.class}, new List<Object> {record});


### PR DESCRIPTION
Since unit of work class has no sharing declaration, it would inherit the sharing of the calling class regardless of it running in system mode. 
This change gives a flexibility to set the uow sharing mode, independent of the calling class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/475)
<!-- Reviewable:end -->
