### PR TITLE
Fixes #440 - changes the few tests that are exercising CRUD/FLS enforcement to prefer the 'Minimum Access - Salesforce' profile since that is a more reliable Profile in most modern orgs

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -378,7 +378,7 @@ private with sharing class fflib_SObjectSelectorTest
 	static void toSOQL_When_UserModeAndUserCannnotReadObject_Expect_QueryException(){
 		AccessLevelOpportunitySelector sel = new AccessLevelOpportunitySelector();
 
-		User u = getLimitedReadOnlyUser();
+		User u = getMinimumAccessUser();
 		System.runAs(u){
 			try{
 				System.debug(sel.newQueryFactory().toSOQL());
@@ -399,7 +399,7 @@ private with sharing class fflib_SObjectSelectorTest
 	static void toSOQL_When_SystemModeAndUserCannnotReadObject_Expect_Success(){
 		AccessLevelOpportunitySelector sel = new AccessLevelOpportunitySelector(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
 
-		User u = getLimitedReadOnlyUser();
+		User u = getMinimumAccessUser();
 		System.runAs(u){
 			sel.selectSObjectsById(new Set<Id>{fflib_IDGenerator.generate(Opportunity.SObjectType)});
 		}
@@ -410,7 +410,7 @@ private with sharing class fflib_SObjectSelectorTest
 		AccessLevelAccountSelector sel = new AccessLevelAccountSelector();
 
 		//Account has Read access by the limited read only user but no FLS access
-		User u = getLimitedReadOnlyUser();
+		User u = getMinimumAccessUser();
 		System.runAs(u){
 			try{
 				System.debug(sel.newQueryFactory().toSOQL());
@@ -433,7 +433,7 @@ private with sharing class fflib_SObjectSelectorTest
 		AccessLevelAccountSelector sel = new AccessLevelAccountSelector(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
 
 		//Account has Read access by the limited read only user but no FLS access
-		User u = getLimitedReadOnlyUser();
+		User u = getMinimumAccessUser();
 		System.runAs(u){
 			sel.selectSObjectsById(new Set<Id>{fflib_IDGenerator.generate(Account.SObjectType)});
 		}
@@ -651,8 +651,8 @@ private with sharing class fflib_SObjectSelectorTest
 		return testUser;
 	}
 
-	private static User getLimitedReadOnlyUser(){
-		return fflib_SecurityUtilsTest.setupTestUser('Read Only');
+	private static User getMinimumAccessUser(){
+		return fflib_SecurityUtilsTest.setupTestUser(true);
 	}
 
 	@IsTest

--- a/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
@@ -79,22 +79,20 @@ private class fflib_SecurityUtilsTest {
 	}
 
 	@TestVisible
-	static User setupTestUser(String profileName){
+	static User setupTestUser(Boolean limitedAccess){
 		Profile p;
-		Boolean applyReadOnlyPermissionSet = false;
-		if (profileName == 'Read Only') {
-			applyReadOnlyPermissionSet = true;
+
+		if (limitedAccess) {
 			try {
-				p = getProfile(profileName);
+				p = getProfile('Minimum Access - Salesforce');
 			} catch (QueryException ex) {
 				if (ex.getMessage().contains('List has no rows for assignment to SObject')) {
-					// #315 If the "Read Only" Profile is absent, then assume it's a Spring '21 org and see if there's a
-					// "Minimum Access - Salesforce" Profile we can use instead.
-					p = getProfile('Minimum Access - Salesforce');
+					//#440 - not ideal, but we'll fall back to the rather liberally permissioned 'Read Only' profile that exists in very old orgs
+					p = getProfile('Read Only');
 				}
 			}
 		} else {
-			p = getProfile(profileName);
+			p = getProfile('System Administrator');
 		}
 
 		//username global uniqueness is still enforced in tests 
@@ -118,7 +116,7 @@ private class fflib_SecurityUtilsTest {
 		);
 		insert usr;
 
-		if (applyReadOnlyPermissionSet) {
+		if (limitedAccess) {
 			// #315 We need to assign the Perm Set to grant Account "Read" access
 			PermissionSet accountReadPS = [SELECT Id FROM PermissionSet WHERE Name = 'ReadOnlyPermissionSet'];
 			PermissionSetAssignment psa = new PermissionSetAssignment(AssigneeId = usr.Id, PermissionSetId = accountReadPS.Id);
@@ -129,7 +127,7 @@ private class fflib_SecurityUtilsTest {
 
 	@isTest
 	static void readonly_field_access() {
-		User testUser = setupTestUser('Read Only');
+		User testUser = setupTestUser(true);
 		System.runAs(testUser){
 			{
 				fflib_SecurityUtils.SecurityException ex;
@@ -172,7 +170,7 @@ private class fflib_SecurityUtilsTest {
 
 	@isTest
 	static void readonly_object_access() {
-		User testUser = setupTestUser('Read Only');
+		User testUser = setupTestUser(true);
 		System.runAs(testUser){
 			{
 				fflib_SecurityUtils.SecurityException ex;
@@ -226,7 +224,7 @@ private class fflib_SecurityUtilsTest {
 
 	@isTest
 	static void readonly_objectAndField_access() {
-		User testUser = setupTestUser('Read Only');
+		User testUser = setupTestUser(true);
 		System.runAs(testUser){
 			{
 				fflib_SecurityUtils.SecurityException ex;
@@ -311,7 +309,7 @@ private class fflib_SecurityUtilsTest {
 
 	@isTest
 	static void sysadmin_objectAndField_access() {
-		User testUser = setupTestUser('System Administrator');
+		User testUser = setupTestUser(false);
 		System.runAs(testUser){
 			fflib_SecurityUtils.checkInsert(
 				Account.SObjectType,


### PR DESCRIPTION
My first cut at fixing this bug was to try to find an SObject that the Read Only profile DIDN'T grant Read access to. Well, that was a fool's errand because even though there were some Standard Objects that didn't have Object Read access, the FLS on the object granted Read access to every field on those Standard Objects.

I backed away from trying to find a way to thread that needle and instead applied a bit more of a pragmatic approach. Rather than preferring the 'Read Only' profile and if it doesn't exist, create a Minimum Access user and assign them a well-known set of Perms via a Perm Set, let's just start with that (i.e. always prefer the Minimum Access user)

There are potential regressions here for orgs that don't have the Minimum Access profile which does exist out in the wild. Those orgs will fall back to the 'Read Only' profile .. and it's likely that the same tests that are broken as reported in #440 will continue to be broken. But at least this patch fixes the more common case of people not being able to get a clean test run if they create a brand spanking new Developer Edition org (not scratch org)

I tested this on a clean DE org and on a Scratch Org of edition Developer -- tests pass cleanly in both (and prior to this fix, the tests failed as outlined in #440 in the DE org)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/482)
<!-- Reviewable:end -->
