### PR TITLE
Fixes #487 - uses the explicit relationship name rather than the SObject inference (deprecated) method for resolving the relationship name

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -619,7 +619,7 @@ private with sharing class fflib_SObjectSelectorTest
 
 			fflib_QueryFactory qf = newQueryFactory();
 
-			oSel.addQueryFactorySubselect(qf);
+			oSel.addQueryFactorySubselect(qf,'Opportunities');
 
 			return qf.toSOQL();
 		}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/493)
<!-- Reviewable:end -->
