### PR TITLE
Type casting bugfix

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -179,7 +179,7 @@ public virtual class fflib_SObjects
 		Set<String> result = new Set<String>();
 		for (SObject record : getRecords())
 		{
-			result.add(String.valueOf(record.get(field)));
+			result.add((String) record.get(field));
 		}
 		return result;
 	}

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -179,7 +179,7 @@ public virtual class fflib_SObjects
 		Set<String> result = new Set<String>();
 		for (SObject record : getRecords())
 		{
-			result.add((String) record.get(field));
+			result.add(String.valueOf(record.get(field)));
 		}
 		return result;
 	}
@@ -254,7 +254,7 @@ public virtual class fflib_SObjects
 		{
 			for (SObjectField field : fields)
 			{
-				if (String.isNotBlank((String) record.get(field))) continue;
+				if (String.isNotBlank(String.valueOf(record.get(field)))) continue;
 
 				result.add(record);
 				break;
@@ -276,7 +276,7 @@ public virtual class fflib_SObjects
 			Boolean allBlank = true;
 			for (SObjectField field : fields)
 			{
-				if (String.isNotBlank((String) record.get(field)))
+				if (String.isNotBlank(String.valueOf(record.get(field))))
 				{
 					allBlank = false;
 					break;
@@ -311,7 +311,7 @@ public virtual class fflib_SObjects
 		{
 			for (SObjectField field : fields)
 			{
-				if (String.isNotBlank((String) record.get(field)))
+				if (String.isNotBlank(String.valueOf(record.get(field))))
 				{
 					result.add(record);
 					break;
@@ -334,7 +334,7 @@ public virtual class fflib_SObjects
 			Boolean allNonBlank = true;
 			for (SObjectField field : fields)
 			{
-				if (String.isBlank((String) record.get(field)))
+				if (String.isBlank(String.valueOf(record.get(field))))
 				{
 					allNonBlank = false;
 					break;

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -121,6 +121,13 @@ public class fflib_SObjectsTest
 
 		System.assertEquals(3, domain.selectWithoutShippingCountry().size());
 	}
+	@IsTest
+	static void itShouldReturnRecordsWithoutFieldValuesForNonStringFields()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assertEquals(4, domain.selectWithoutNumberOfEmployees().size());
+	}
 
 	@IsTest
 	static void itShouldReturnRecordsWithoutAllFieldValues()
@@ -137,13 +144,20 @@ public class fflib_SObjectsTest
 
 		System.assert(domain.selectWithShippingCountry().size() == 4);
 	}
+	@IsTest
+	static void itShouldReturnRecordsWithNumberOfEmployees()
+	{
+		DomainAccounts domain = generateDomain();
+
+		System.assert(domain.selectWithNumberOfEmployees().size() == 3);
+	}
 
 	@IsTest
 	static void itShouldReturnRecordsWithAllFieldValues()
 	{
 		DomainAccounts domain = generateDomain();
 
-		System.assert(domain.selectPopulatedRecords().size() == 4);
+		System.assert(domain.selectPopulatedRecords().size() == 2);
 	}
 
 	@IsTest
@@ -167,6 +181,44 @@ public class fflib_SObjectsTest
 		System.assert(
 				domain.getFieldValues(Schema.Account.ShippingCountry)
 						.equals(expected)
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnFieldValuesForNonStringFields()
+	{
+		DomainAccounts domain = generateDomain();
+
+		final Set<Integer> expectedOriginalType = new Set<Integer>
+		{
+				null,
+				10,
+				20,
+				30
+		};
+
+		System.assert(
+				domain.getFieldValues(Schema.Account.NumberOfEmployees)
+						.equals(expectedOriginalType)
+		);
+	}
+
+	@IsTest
+	static void itShouldReturnStringFieldValuesForNonStringFields()
+	{
+		DomainAccounts domain = generateDomain();
+
+		final Set<String> expectedStrings = new Set<String>
+		{
+				null,
+				'10',
+				'20',
+				'30'
+		};
+
+		System.assert(
+				domain.getStringFieldValues(Schema.Account.NumberOfEmployees)
+						.equals(expectedStrings)
 		);
 	}
 
@@ -247,11 +299,11 @@ public class fflib_SObjectsTest
 				{
 						new Account(Name = 'A', ShippingCountry = 'USA'),
 						new Account(Name = 'B', ShippingCountry = 'Ireland'),
-						new Account(Name = 'C', ShippingCountry = 'UK'),
+						new Account(Name = 'C', ShippingCountry = 'UK', NumberOfEmployees = 10),
 						new Account(Name = 'D', ShippingCountry = ''),
-						new Account(Name = 'E'),
+						new Account(Name = 'E', NumberOfEmployees = 20),
 						new Account(),
-						new Account(Name = 'G', ShippingCountry = 'Canada')
+						new Account(Name = 'G', ShippingCountry = 'Canada', NumberOfEmployees = 30)
 				}
 		);
 		return domain;
@@ -295,13 +347,28 @@ public class fflib_SObjectsTest
 			);
 		}
 
+		public List<Account> selectWithoutNumberOfEmployees()
+		{
+			return (List<Account>) getRecordsWithBlankFieldValues(
+							Schema.Account.NumberOfEmployees
+			);
+		}
+
+		public List<Account> selectWithNumberOfEmployees()
+		{
+			return (List<Account>) getRecordsWithNotBlankFieldValues(
+							Schema.Account.NumberOfEmployees
+			);
+		}
+
 		public List<Account> selectWithEmptyRecord()
 		{
 			return (List<Account>) getRecordsWithAllBlankFieldValues(
 					new Set<Schema.SObjectField>
 					{
 							Schema.Account.Name,
-							Schema.Account.ShippingCountry
+							Schema.Account.ShippingCountry,
+							Schema.Account.NumberOfEmployees
 					}
 			);
 		}
@@ -312,7 +379,8 @@ public class fflib_SObjectsTest
 					new Set<Schema.SObjectField>
 					{
 							Schema.Account.Name,
-							Schema.Account.ShippingCountry
+							Schema.Account.ShippingCountry,
+							Schema.Account.NumberOfEmployees
 					}
 			);
 		}

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -204,22 +204,20 @@ public class fflib_SObjectsTest
 	}
 
 	@IsTest
-	static void itShouldReturnStringFieldValuesForNonStringFields()
+	static void getStringFieldValuesShouldThrowClassCastExceptionForNonStringFields()
 	{
 		DomainAccounts domain = generateDomain();
 
-		final Set<String> expectedStrings = new Set<String>
+		try
 		{
-				null,
-				'10',
-				'20',
-				'30'
-		};
-
-		System.assert(
-				domain.getStringFieldValues(Schema.Account.NumberOfEmployees)
-						.equals(expectedStrings)
-		);
+			domain.getStringFieldValues(Schema.Account.NumberOfEmployees);
+			Assert.fail('Expected ClassCastException because NumberOfEmployees is not a Text field');
+		}
+		catch (System.TypeException expected)
+		{
+			System.assert(expected.getMessage().contains('Invalid conversion from runtime type'),
+					'Unexpected exception message: ' + expected.getMessage());
+		}
 	}
 
 	@IsTest


### PR DESCRIPTION
Fixes #495

Replace the manual type casting of field values into String with `String.valueOf()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/496)
<!-- Reviewable:end -->
