### PR TITLE
NonReferenceFieldException throw when external object referencing a parent field via indirect lookup on a custom object.

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -123,7 +123,8 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 				fflib_SecurityUtils.checkFieldIsReadable(lastSObjectType, token);
 			}
 
-			if (token != null && i.hasNext() && tokenDescribe.getSoapType() == Schema.SoapType.ID) {
+			if (token != null && i.hasNext() && (tokenDescribe.getSoapType() == Schema.SoapType.ID
+				|| (tokenDescribe.getSoapType() == Schema.SoapType.STRING && tokenDescribe.getType() == Schema.DisplayType.REFERENCE))) {
 				List<Schema.sObjectType> relatedObjs = tokenDescribe.getReferenceTo(); //if it's polymorphic, it matters which one we use - i.e. Lead.Owner is GROUP|USER and each has different fields.
 
 				if (relatedObjs.size() == 1 || relatedSObjectType == null) {


### PR DESCRIPTION
**Describe the bug**
I have a situation where I am querying an external object that has an indirect lookup field to a field on a custom object in Salesforce. The NonReferenceFieldException is thrown when trying to do so. I believe if the soap type of the field is a string and the display type is reference that this should capture this situation and it should be safe to use the selector pattern. Please advise if this solution makes sense. 

**To Reproduce**
It will take some time to set up and environment with an external object that has a indirect lookup to a custom (non external) object.

**Expected behavior**
Expect the selector pattern to return fields via indirect lookup.


**Version**
This error is current happening as of 2024-10-29.
