### PR TITLE
Devops/adjustments to build script from SFv2 architecture change

### DIFF
--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Setup the config parameters needed
         run: sf config set target-dev-hub SFDX-ENV --global #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
       - name: Create the scratch org
-        run: sf org create scratch --definition-file config/project-scratch-def.json --set-default --duration-days 1 --no-track-source
+        run: sf org create scratch --definition-file config/project-scratch-def.json --set-default --duration-days 1 --no-track-source --alias fflibapexcommon
       # - name: Install required dependency frameworks
         # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-mocks --path sfdx-source/apex-mocks
       - name: Clone fflib-apex-mocks repo
         run: mkdir temp && git clone https://github.com/apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-mocks"
       - name: Deploy and compile the fflib-apex-mocks codebase
-        run: cd temp/fflib-apex-mocks && sf project deploy start --ignore-conflicts && cd ../..
+        run: cd temp/fflib-apex-mocks && sf project deploy start --ignore-conflicts --target-org fflibapexcommon && cd ../..
       - name: Deploy and compile the codebase
         run: sf project deploy start
       - name: Run the core framework tests
@@ -39,7 +39,7 @@ jobs:
       # that could mask a test failure. A much more involved solution would've been to do a workflow_dispatch to the samplecode project.
       - name: Install sample code project to verify with
         # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-common-samplecode --path sfdx-source/apex-common-samplecode
-        run: git clone https://github.com/apex-enterprise-patterns/fflib-apex-common-samplecode.git "temp/fflib-apex-common-samplecode" && cd temp/fflib-apex-common-samplecode && sf project deploy start --ignore-conflicts && cd ../..
+        run: git clone https://github.com/apex-enterprise-patterns/fflib-apex-common-samplecode.git "temp/fflib-apex-common-samplecode" && cd temp/fflib-apex-common-samplecode && sf project deploy start --ignore-conflicts --target-org fflibapexcommon  && cd ../..
       - name: Run the core framework tests and the sample code project tests
         run: sf apex run test --wait 5
       - name: Destroy scratch org

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -28,7 +28,7 @@ jobs:
       # - name: Install required dependency frameworks
         # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-mocks --path sfdx-source/apex-mocks
       - name: Clone fflib-apex-mocks repo
-        run: mkdir temp && git clone git@github.com:apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-mocks"
+        run: mkdir temp && git clone https://github.com/apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-mocks"
       - name: Deploy and compile the fflib-apex-mocks codebase
         run: cd temp/fflib-apex-mocks && sf project deploy start --ignore-conflicts && cd ../..
       - name: Deploy and compile the codebase
@@ -39,7 +39,7 @@ jobs:
       # that could mask a test failure. A much more involved solution would've been to do a workflow_dispatch to the samplecode project.
       - name: Install sample code project to verify with
         # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-common-samplecode --path sfdx-source/apex-common-samplecode
-        run: git clone git@github.com:apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-common-samplecode" && cd temp/fflib-apex-common-samplecode && sf project deploy start --ignore-conflicts && cd ../..
+        run: git clone https://github.com/apex-enterprise-patterns/fflib-apex-common-samplecode.git "temp/fflib-apex-common-samplecode" && cd temp/fflib-apex-common-samplecode && sf project deploy start --ignore-conflicts && cd ../..
       - name: Run the core framework tests and the sample code project tests
         run: sf apex run test --wait 5
       - name: Destroy scratch org

--- a/.github/workflows/deploy.and.test.yml
+++ b/.github/workflows/deploy.and.test.yml
@@ -19,14 +19,18 @@ jobs:
         uses: apex-enterprise-patterns/setup-sfdx@v2 #We're using a fork of https://github.com/sfdx-actions/setup-sfdx for safety
         with:
           sfdx-auth-url: ${{ secrets.DEVHUB_SFDXURL }}
-      - name: Install the required plugins
-        run: echo y | sf plugins install shane-sfdx-plugins
+      # - name: Install the required plugins
+      #   run: echo y | sf plugins install shane-sfdx-plugins
       - name: Setup the config parameters needed
         run: sf config set target-dev-hub SFDX-ENV --global #Even though the setup-sfdx action uses --setdefaultdevhubusername, it doesn't seem to stick since it uses --setdefaultusername so we brute force it here
       - name: Create the scratch org
         run: sf org create scratch --definition-file config/project-scratch-def.json --set-default --duration-days 1 --no-track-source
-      - name: Install required dependency frameworks
-        run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-mocks --path sfdx-source/apex-mocks
+      # - name: Install required dependency frameworks
+        # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-mocks --path sfdx-source/apex-mocks
+      - name: Clone fflib-apex-mocks repo
+        run: mkdir temp && git clone git@github.com:apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-mocks"
+      - name: Deploy and compile the fflib-apex-mocks codebase
+        run: cd temp/fflib-apex-mocks && sf project deploy start --ignore-conflicts && cd ../..
       - name: Deploy and compile the codebase
         run: sf project deploy start
       - name: Run the core framework tests
@@ -34,7 +38,8 @@ jobs:
       # Intentionally install the Sample Code after the core AEP Commons test pass succeeds so that we don't deploy anything in Sample Code
       # that could mask a test failure. A much more involved solution would've been to do a workflow_dispatch to the samplecode project.
       - name: Install sample code project to verify with
-        run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-common-samplecode --path sfdx-source/apex-common-samplecode
+        # run: sf shane github src install --convert --githubuser apex-enterprise-patterns --repo fflib-apex-common-samplecode --path sfdx-source/apex-common-samplecode
+        run: git clone git@github.com:apex-enterprise-patterns/fflib-apex-mocks.git "temp/fflib-apex-common-samplecode" && cd temp/fflib-apex-common-samplecode && sf project deploy start --ignore-conflicts && cd ../..
       - name: Run the core framework tests and the sample code project tests
         run: sf apex run test --wait 5
       - name: Destroy scratch org


### PR DESCRIPTION
Adjustments needed based on build job failures on other PRs where the shane-sfdx-plugins appears to be failing; probably due to SFv2 architecture no longer support `force:source:deploy`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/499)
<!-- Reviewable:end -->
