### PR TITLE
Changing test to not use Order object

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -646,19 +646,19 @@ private with sharing class fflib_SObjectSelectorTest
 		}
 	}
 
-	private class OrderSelector extends fflib_SObjectSelector{
-		public OrderSelector(){
+	private class ListEmailSelector extends fflib_SObjectSelector{
+		public ListEmailSelector(){
 			super(false,DataAccess.SYSTEM_MODE);
 		}
 
 		public Schema.SObjectType getSObjectType(){
-			return Order.SObjectType;
+			return ListEmail.SObjectType;
 		}
 
 		public List<Schema.SObjectField> getSObjectFieldList(){
 			return new List<Schema.SObjectField> {
-					Order.Id,
-					Order.OrderNumber
+					ListEmail.Id,
+					ListEmail.Name
 			};
 		}
 	}
@@ -823,19 +823,19 @@ private with sharing class fflib_SObjectSelectorTest
 		AccessLevelOpportunitySelector oppSel = new AccessLevelOpportunitySelector();
 		fflib_QueryFactory oppQF = oppSel.addQueryFactorySubselect(cQF);
 
-		OrderSelector orderSel = new OrderSelector();
-		fflib_QueryFactory orderQF = orderSel.addQueryFactorySubselect(oppQF);
+		ListEmailSelector listEmailSel = new ListEmailSelector();
+		fflib_QueryFactory listEmailQF = listEmailSel.addQueryFactorySubselect(oppQF);
 
 		TaskSelector tSel = new TaskSelector();
-		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(orderQF);
+		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(listEmailQF);
 
 		String expected
 				= 'SELECT name, id, annualrevenue, accountnumber, '
 				+   '(SELECT id, contractnumber, '
 				+     '(SELECT name, id, amount, closedate, '
-				+       '(SELECT id, ordernumber, '
+				+       '(SELECT id, name, '
 				+         '(SELECT id, subject FROM Tasks ORDER BY Subject ASC NULLS FIRST )  '
-				+       'FROM Orders ORDER BY OrderNumber ASC NULLS FIRST )  '
+				+       'FROM ListEmails ORDER BY Name ASC NULLS FIRST )  '
 				+     'FROM Opportunities ORDER BY Name ASC NULLS FIRST )  '
 				+   'FROM Contracts ORDER BY ContractNumber ASC NULLS FIRST )  '
 				+ 'FROM Account WITH USER_MODE ORDER BY Name ASC NULLS FIRST ';


### PR DESCRIPTION
I also ran into the issue identified in https://github.com/apex-enterprise-patterns/fflib-apex-common/issues/505 within my project since my org does not have Orders enabled.

I changed Order object to List Email since that seems to be one of few that do not need to be enabled and has Activities enabled. I am open to refactoring to a different object if List Email is not preferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/506)
<!-- Reviewable:end -->
