### PR TITLE
Fix spelling and grammar errors in comments

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -86,7 +86,7 @@ public virtual class fflib_Application
 		 *   if set via the setMock method
 		 *
 		 * @remark If mock is set, the list of SObjectType in the mock could be different
-		 *         then the list of SObjectType specified in this method call
+		 *         than the list of SObjectType specified in this method call
 		 **/
 		public virtual fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes)
 		{
@@ -102,7 +102,7 @@ public virtual class fflib_Application
 		 *   if set via the setMock method
 		 *
 		 * @remark If mock is set, the list of SObjectType in the mock could be different
-		 *         then the list of SObjectType specified in this method call
+		 *         than the list of SObjectType specified in this method call
 		 **/
 		public virtual fflib_ISObjectUnitOfWork newInstance(List<SObjectType> objectTypes, fflib_SObjectUnitOfWork.IDML dml)
 		{
@@ -139,7 +139,7 @@ public virtual class fflib_Application
 		 *   Note that this will not check the Apex Classes given actually implement the interfaces
 		 *     as this information is not presently available via the Apex runtime
 		 *
-		 * @param serviceInterfaceTypeByServiceImplType Map ofi interfaces to classes
+		 * @param serviceInterfaceTypeByServiceImplType Map of interfaces to classes
 		 **/
 		public ServiceFactory(Map<Type, Type> serviceInterfaceTypeByServiceImplType)
 		{
@@ -189,11 +189,11 @@ public virtual class fflib_Application
 		public SelectorFactory() { }
 
 		/**
-		 * Consturcts a Selector Factory linking SObjectType's with Apex Classes implement the fflib_ISObjectSelector interface
+		 * Constructs a Selector Factory linking SObjectType's with Apex Classes implement the fflib_ISObjectSelector interface
 		 *   Note that the factory does not check the given Apex Classes implement the interface
 		 *     currently this is not possible in Apex.
 		 *
-		 * @Param sObjectBySelectorType Map of SObjectType's to Selector Apex Classes
+		 * @param sObjectBySelectorType Map of SObjectType's to Selector Apex Classes
 		 **/
 		public SelectorFactory(Map<SObjectType, Type> sObjectBySelectorType)
 		{

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
@@ -215,7 +215,7 @@ public interface fflib_ISObjectUnitOfWork
      **/
     void commitWork();
     /**
-     * Register a generic peace of work to be invoked during the commitWork phase
+     * Register a generic piece of work to be invoked during the commitWork phase
      *
      * @param work Work to be registered
      **/

--- a/sfdx-source/apex-common/main/classes/fflib_StringBuilder.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_StringBuilder.cls
@@ -27,7 +27,7 @@
 /**
  * Helper class, roughly based on the Java version, but subclassed to assist in a number of use cases in this library
  * 
- * NOTE: Aspects of this where developed before recent improvements to String handling, as such could likely be enhanced at this stage.
+ * NOTE: Aspects of this were developed before recent improvements to String handling, as such could likely be enhanced at this stage.
  **/
 public virtual class fflib_StringBuilder
 {


### PR DESCRIPTION
## Summary

  This PR corrects several spelling and grammar errors found in code comments across the fflib-apex-common library to
   improve documentation clarity and professionalism.

 ## Changes Made

  - fflib_Application.cls
    - Fixed "Map ofi interfaces" → "Map of interfaces" (line 142)
    - Fixed "Consturcts" → "Constructs" (line 192)
    - Fixed `@Param` → `@param` for proper JavaDoc formatting (line 196)
    - Fixed "then" → "than" in comparison context (lines 89, 105)
  - fflib_ISObjectUnitOfWork.cls
    - Fixed "Register a generic peace of work" → "Register a generic piece of work" (line 218)
  - fflib_StringBuilder.cls
    - Fixed "where developed" → "were developed" (line 30)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/513)
<!-- Reviewable:end -->
