### PR TITLE
Fixing string format message that didnt include placeholder

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -336,7 +336,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
         // Assert Results
         System.assertEquals(didFail, true, 'didFail');
-        System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+        System.assert(caughtEx.getMessage().contains('REQUIRED_FIELD_MISSING'), String.format('Exception message was {0}', new List<String> { caughtEx.getMessage() }));
 
         assertEvents(new List<String> {
                 'onCommitWorkStarting'
@@ -387,7 +387,7 @@ private with sharing class fflib_SObjectUnitOfWorkTest
 
         // Assert Results
         System.assertEquals(didFail, true, 'didFail');
-        System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was ', new List<String> { caughtEx.getMessage() }));
+        System.assert(caughtEx.getMessage().contains('Work failed.'), String.format('Exception message was {0}', new List<String> { caughtEx.getMessage() }));
 
         assertEvents(new List<String> {
                 'onCommitWorkStarting'


### PR DESCRIPTION
Describe the bug
I encountered an error when running fflib_SObjectUnitOfWorkTest in my environment. Says an assertion failed because of an incomplete exception message. I noticed that the assertions where only missing a placeholder so I added it.

To Reproduce
Run all tests for the fflib_SObjectUnitOfWorkTest class.

Expected behavior
The assertion should be true and contain the expected exception message.

Version
This error is current happening as of 2025-10-27

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/517)
<!-- Reviewable:end -->
