### PR TITLE
Fix test failures when field encryption is enabled for SOQL order by clauses

### DIFF
--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -833,16 +833,18 @@ private with sharing class fflib_SObjectSelectorTest
 		TaskSelector tSel = new TaskSelector();
 		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(listEmailQF);
 
-		String expected
-				= 'SELECT name, id, annualrevenue, accountnumber, '
-				+   '(SELECT id, contractnumber, '
-				+     '(SELECT name, id, amount, closedate, '
-				+       '(SELECT id, name, '
-				+         '(SELECT id, subject FROM Tasks ORDER BY Subject ASC NULLS FIRST )  '
-				+       'FROM ListEmails ORDER BY Name ASC NULLS FIRST )  '
-				+     'FROM Opportunities ORDER BY Name ASC NULLS FIRST )  '
-				+   'FROM Contracts ORDER BY ContractNumber ASC NULLS FIRST )  '
-				+ 'FROM Account WITH USER_MODE ORDER BY Name ASC NULLS FIRST ';
+    String expected = String.format(
+      'SELECT name, id, annualrevenue, accountnumber, ' +
+      '(SELECT id, contractnumber, ' +
+      '(SELECT name, id, amount, closedate, ' +
+      '(SELECT id, name, ' +
+      '(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
+      'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
+      'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
+      'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
+      'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ', 
+      new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
+    );
 
 		Assert.areEqual(expected,aQF.toSOQL());
 	}

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -834,16 +834,16 @@ private with sharing class fflib_SObjectSelectorTest
 		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(listEmailQF);
 
 	String expected = String.format(
-	  'SELECT name, id, annualrevenue, accountnumber, ' +
-	  '(SELECT id, contractnumber, ' +
-	  '(SELECT name, id, amount, closedate, ' +
-	  '(SELECT id, name, ' +
-	  '(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
-	  'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
-	  'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
-	  'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
-	  'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ', 
-	  new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
+		'SELECT name, id, annualrevenue, accountnumber, ' +
+			'(SELECT id, contractnumber, ' +
+				'(SELECT name, id, amount, closedate, ' +
+					'(SELECT id, name, ' +
+						'(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
+					'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
+				'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
+			'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
+		'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ',
+		new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
 	);
 
 		Assert.areEqual(expected,aQF.toSOQL());

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -456,10 +456,14 @@ private with sharing class fflib_SObjectSelectorTest
 	static void toSOQL_When_SystemModeAndChildRelationship_Expect_WellFormedSOQL(){
 		AccessLevelAccountSelector sel = new AccessLevelAccountSelector(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
 
-		String soql = sel.createSelectAccountWithOpportunitiesSOQL();
+    AccessLevelOpportunitySelector innerSelector = new AccessLevelOpportunitySelector();
 
-		String expected = String.format('SELECT name, id, annualrevenue, accountnumber, (currencyisocode, )?\\(SELECT name, id, amount, closedate(, currencyisocode)? FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {0} ASC NULLS FIRST ',
-			new List<String>{sel.getOrderBy()});
+    String soql = sel.createSelectAccountWithOpportunitiesSOQL();
+
+    String expected = String.format(
+      'SELECT name, id, annualrevenue, accountnumber, (currencyisocode, )?\\(SELECT name, id, amount, closedate(, currencyisocode)? FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {1} ASC NULLS FIRST ',
+      new List<String>{ innerSelector.getOrderBy(), sel.getOrderBy() }
+    );
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -456,14 +456,14 @@ private with sharing class fflib_SObjectSelectorTest
 	static void toSOQL_When_SystemModeAndChildRelationship_Expect_WellFormedSOQL(){
 		AccessLevelAccountSelector sel = new AccessLevelAccountSelector(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
 
-    AccessLevelOpportunitySelector innerSelector = new AccessLevelOpportunitySelector();
+	AccessLevelOpportunitySelector innerSelector = new AccessLevelOpportunitySelector();
 
-    String soql = sel.createSelectAccountWithOpportunitiesSOQL();
+	String soql = sel.createSelectAccountWithOpportunitiesSOQL();
 
-    String expected = String.format(
-      'SELECT name, id, annualrevenue, accountnumber, (currencyisocode, )?\\(SELECT name, id, amount, closedate(, currencyisocode)? FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {1} ASC NULLS FIRST ',
-      new List<String>{ innerSelector.getOrderBy(), sel.getOrderBy() }
-    );
+	String expected = String.format(
+	  'SELECT name, id, annualrevenue, accountnumber, (currencyisocode, )?\\(SELECT name, id, amount, closedate(, currencyisocode)? FROM Opportunities ORDER BY {0} ASC NULLS FIRST \\)  FROM Account WITH SYSTEM_MODE ORDER BY {1} ASC NULLS FIRST ',
+	  new List<String>{ innerSelector.getOrderBy(), sel.getOrderBy() }
+	);
 		Pattern soqlPattern = Pattern.compile(expected);
 		Matcher soqlMatcher = soqlPattern.matcher(soql);
 		System.assert(soqlMatcher.matches(),'Expected: ' + expected + ' Actual:' + soql);
@@ -833,18 +833,18 @@ private with sharing class fflib_SObjectSelectorTest
 		TaskSelector tSel = new TaskSelector();
 		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(listEmailQF);
 
-    String expected = String.format(
-      'SELECT name, id, annualrevenue, accountnumber, ' +
-      '(SELECT id, contractnumber, ' +
-      '(SELECT name, id, amount, closedate, ' +
-      '(SELECT id, name, ' +
-      '(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
-      'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
-      'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
-      'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
-      'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ', 
-      new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
-    );
+	String expected = String.format(
+	  'SELECT name, id, annualrevenue, accountnumber, ' +
+	  '(SELECT id, contractnumber, ' +
+	  '(SELECT name, id, amount, closedate, ' +
+	  '(SELECT id, name, ' +
+	  '(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
+	  'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
+	  'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
+	  'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
+	  'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ', 
+	  new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
+	);
 
 		Assert.areEqual(expected,aQF.toSOQL());
 	}


### PR DESCRIPTION
See discussion for order by support when field encryption is enabled. Ideally, we may want to look ensuring getOrderBy() it utilised with a custom PMD rule or a better testing framework for SOQL string output

https://github.com/apex-enterprise-patterns/fflib-apex-common/pull/452

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/523)
<!-- Reviewable:end -->
