### PR TITLE
Fix for #512 - SObjectSelectorTest failing in multicurrency orgs

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -432,7 +432,7 @@ public abstract with sharing class fflib_SObjectSelector
 			queryFactory.selectField(relationshipFieldPath + '.' + field.getDescribe().getName(), this.getSObjectType());
 		}
 		// Automatically select the CurrencyIsoCode for MC orgs (unless the object is a known exception to the rule)
-		if(UserInfo.isMultiCurrencyOrganization() && CURRENCY_ISO_CODE_ENABLED){
+		if(isCurrencyIsoCodeAvailable()){
 			queryFactory.selectField(relationshipFieldPath+'.CurrencyIsoCode', getSObjectType());
 		}
      }
@@ -532,7 +532,7 @@ public abstract with sharing class fflib_SObjectSelector
 	                queryFactory.selectFieldSet(fieldSet);
 	
 	        // Automatically select the CurrencyIsoCode for MC orgs (unless the object is a known exception to the rule)
-	        if(UserInfo.isMultiCurrencyOrganization() && CURRENCY_ISO_CODE_ENABLED)
+	        if(isCurrencyIsoCodeAvailable())
 	            queryFactory.selectField('CurrencyIsoCode', getSObjectType());
         }
         
@@ -555,5 +555,13 @@ public abstract with sharing class fflib_SObjectSelector
         queryFactory.setSortSelectFields(m_sortSelectFields);           
 
         return queryFactory;    
-    }    
+    }
+
+    /**
+     * Returns true if the CurrencyIsoCode field is available on this SObject
+     */
+    @TestVisible
+    private Boolean isCurrencyIsoCodeAvailable() {
+        return UserInfo.isMultiCurrencyOrganization() && CURRENCY_ISO_CODE_ENABLED;
+    }
 }

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -714,18 +714,24 @@ private with sharing class fflib_SObjectSelectorTest
 		//Given		
 
 		CaseCommentSelector ccSelector = new CaseCommentSelector(fflib_SObjectSelector.DataAccess.LEGACY);
+		CaseSelector caseSelector = new CaseSelector();
+		UserSelector userSelector = new UserSelector();
 		fflib_QueryFactory qf = ccSelector.newQueryFactory();
-		new CaseSelector().configureQueryFactoryFields(qf, 'Parent');
-		new UserSelector().configureQueryFactoryFields(qf, 'Parent.Owner');
+		caseSelector.configureQueryFactoryFields(qf, 'Parent');
+		userSelector.configureQueryFactoryFields(qf, 'Parent.Owner');
 
 
 		Set<String> expectedSelectFields = new Set<String>{
 				'Id', 'CommentBody', 'Parent.Id', 'Parent.OwnerId', 'Parent.Owner.Id', 'Parent.Owner.UserRoleId'
 		};
-		if (UserInfo.isMultiCurrencyOrganization()) {
+		if (ccSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('CurrencyIsoCode');
+		}
+		if (caseSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('Parent.CurrencyIsoCode');
-			expectedSelectFields.add('Parent.Owner.CurrencyIsoCode');  // Because the Selector is for User; Group would not have
+		}
+		if (userSelector.isCurrencyIsoCodeAvailable()) {
+			expectedSelectFields.add('Parent.Owner.CurrencyIsoCode');
 		}
 
 		//When
@@ -746,21 +752,25 @@ private with sharing class fflib_SObjectSelectorTest
 		//Given
 
 		CaseCommentSelector ccSelector = new CaseCommentSelector(fflib_SObjectSelector.DataAccess.LEGACY);
+		CaseSelector caseSelector = new CaseSelector();
+		GroupSelector groupSelector = new GroupSelector();
 		fflib_QueryFactory qf = ccSelector.newQueryFactory();
-		new CaseSelector().configureQueryFactoryFields(qf, 'Parent');
-		new GroupSelector().configureQueryFactoryFields(qf, 'Parent.Owner');
+		caseSelector.configureQueryFactoryFields(qf, 'Parent');
+		groupSelector.configureQueryFactoryFields(qf, 'Parent.Owner');
 
 
 		Set<String> expectedSelectFields = new Set<String>{
 			'Id', 'CommentBody', 'Parent.Id', 'Parent.OwnerId', 'Parent.Owner.Id'
 		};
 		Set<String> unexpectedSelectFields = new Set<String>();
-		if (UserInfo.isMultiCurrencyOrganization()) {
+		if (ccSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('CurrencyIsoCode');
-			expectedSelectFields.add('Parent.CurrencyIsoCode');
-
-			unexpectedSelectFields.add('Parent.Owner.CurrencyIsoCode'); // Because Group does NOT have CurrencyIsoCode
 		}
+		if (caseSelector.isCurrencyIsoCodeAvailable()) {
+			expectedSelectFields.add('Parent.CurrencyIsoCode');
+		}
+		// Group does NOT have CurrencyIsoCode field
+		unexpectedSelectFields.add('Parent.Owner.CurrencyIsoCode');
 
 		//When
 		String soql = qf.toSOQL();
@@ -785,24 +795,26 @@ private with sharing class fflib_SObjectSelectorTest
 	@IsTest
 	static void toSOQL_When_SystemModePolymorphicSelect_Expect_RelatedType() {
 		CaseCommentSelector ccSelector = new CaseCommentSelector(fflib_SObjectSelector.DataAccess.SYSTEM_MODE);
+		CaseSelector caseSelector = new CaseSelector();
+		UserSelector userSelector = new UserSelector();
 		fflib_QueryFactory qf = ccSelector.newQueryFactory();
-		new CaseSelector().configureQueryFactoryFields(qf, 'Parent');
-		new UserSelector().configureQueryFactoryFields(qf, 'Parent.Owner');
+		caseSelector.configureQueryFactoryFields(qf, 'Parent');
+		userSelector.configureQueryFactoryFields(qf, 'Parent.Owner');
 
 		List<String> expectedSelectFields = new List<String>();
 		expectedSelectFields.add('id');
 		expectedSelectFields.add('commentbody');
-		if (UserInfo.isMultiCurrencyOrganization()) {
+		if (ccSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('currencyisocode');
 		}
 		expectedSelectFields.add('parent.ownerid');
 		expectedSelectFields.add('parent.id');
-		if (UserInfo.isMultiCurrencyOrganization()) {
+		if (caseSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('parent.currencyisocode');
 		}
 		expectedSelectFields.add('parent.owner.userroleid');
 		expectedSelectFields.add('parent.owner.id');
-		if (UserInfo.isMultiCurrencyOrganization()) {
+		if (userSelector.isCurrencyIsoCodeAvailable()) {
 			expectedSelectFields.add('parent.owner.currencyisocode');
 		}
 
@@ -834,16 +846,23 @@ private with sharing class fflib_SObjectSelectorTest
 		fflib_QueryFactory tQF = tSel.addQueryFactorySubselect(listEmailQF);
 
 	String expected = String.format(
-		'SELECT name, id, annualrevenue, accountnumber, ' +
-			'(SELECT id, contractnumber, ' +
-				'(SELECT name, id, amount, closedate, ' +
-					'(SELECT id, name, ' +
-						'(SELECT id, subject FROM Tasks ORDER BY {0} ASC NULLS FIRST )  ' +
-					'FROM ListEmails ORDER BY {1} ASC NULLS FIRST )  ' +
-				'FROM Opportunities ORDER BY {2} ASC NULLS FIRST )  ' +
-			'FROM Contracts ORDER BY {3} ASC NULLS FIRST )  ' +
-		'FROM Account WITH USER_MODE ORDER BY {4} ASC NULLS FIRST ',
-		new List<String>{ tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy() }
+		'SELECT name, id, annualrevenue, accountnumber{0}, ' +
+			'(SELECT id, contractnumber{1}, ' +
+				'(SELECT name, id, amount, closedate{2}, ' +
+					'(SELECT id, name{3}, ' +
+						'(SELECT id, subject{4} FROM Tasks ORDER BY {5} ASC NULLS FIRST )  ' +
+					'FROM ListEmails ORDER BY {6} ASC NULLS FIRST )  ' +
+				'FROM Opportunities ORDER BY {7} ASC NULLS FIRST )  ' +
+			'FROM Contracts ORDER BY {8} ASC NULLS FIRST )  ' +
+		'FROM Account WITH USER_MODE ORDER BY {9} ASC NULLS FIRST ',
+		new List<String>{
+			aSel.isCurrencyIsoCodeAvailable() ? ', currencyisocode' : '',
+			cSel.isCurrencyIsoCodeAvailable() ? ', currencyisocode' : '',
+			oppSel.isCurrencyIsoCodeAvailable() ? ', currencyisocode' : '',
+			listEmailSel.isCurrencyIsoCodeAvailable() ? ', currencyisocode' : '',
+			tSel.isCurrencyIsoCodeAvailable() ? ', currencyisocode' : '',
+			tSel.getOrderBy(), listEmailSel.getOrderBy(), oppSel.getOrderBy(), cSel.getOrderBy(), aSel.getOrderBy()
+		}
 	);
 
 		Assert.areEqual(expected,aQF.toSOQL());


### PR DESCRIPTION
Refactor CurrencyIsoCode handling in fflib_SObjectSelector and fix tests for Multicurrency Orgs.

## Copilot generated summary
This pull request refactors how the `CurrencyIsoCode` field is automatically selected for multi-currency organizations in the `fflib_SObjectSelector` class and updates related tests for improved accuracy and maintainability. The main change is the introduction of a new helper method, `isCurrencyIsoCodeAvailable()`, which centralizes the logic for determining when to select the `CurrencyIsoCode` field. This makes the code cleaner and the tests more precise.

**Core Selector Logic Improvements:**

* Added a private `isCurrencyIsoCodeAvailable()` method to `fflib_SObjectSelector` to encapsulate the logic for determining if the `CurrencyIsoCode` field should be included, replacing direct checks with `UserInfo.isMultiCurrencyOrganization()` and `CURRENCY_ISO_CODE_ENABLED`.
* Updated all selector logic to use `isCurrencyIsoCodeAvailable()` instead of the previous inline conditionals, ensuring consistent behavior when selecting the `CurrencyIsoCode` field for SObjects and their relationships. [[1]](diffhunk://#diff-7f26c6a4e41dc4abbd3f2f92a0d98cf01e0d2636720a65222304a080bff59e74L435-R435) [[2]](diffhunk://#diff-7f26c6a4e41dc4abbd3f2f92a0d98cf01e0d2636720a65222304a080bff59e74L535-R535)

**Test Suite Enhancements:**

* Refactored tests in `fflib_SObjectSelectorTest` to use the new `isCurrencyIsoCodeAvailable()` method for determining expected fields, improving test reliability and clarity. [[1]](diffhunk://#diff-314e5680294c1e71cca89c7828025bc6cdc428c4542fa8656b54b8c530c70d18R717-R734) [[2]](diffhunk://#diff-314e5680294c1e71cca89c7828025bc6cdc428c4542fa8656b54b8c530c70d18R755-R773) [[3]](diffhunk://#diff-314e5680294c1e71cca89c7828025bc6cdc428c4542fa8656b54b8c530c70d18R798-R817)
* Improved test coverage for edge cases, such as ensuring `CurrencyIsoCode` is not selected for SObjects (e.g., `Group`) that do not support the field.
* Updated expected SOQL strings in tests to dynamically include the `CurrencyIsoCode` field only when available, increasing the accuracy of assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/525)
<!-- Reviewable:end -->
