### PR TITLE
fix: pmd suppression pass for code-analyzer cleanup

### DIFF
--- a/sfdx-source/apex-common/main/classes/fflib_Application.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Application.cls
@@ -30,6 +30,7 @@
  *   See the sample applications Application.cls file for an example
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.CognitiveComplexity, PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.ApexDoc')
 public virtual class fflib_Application
 {
 	/**

--- a/sfdx-source/apex-common/main/classes/fflib_IDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomain.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IDomain
 {
 	Object getType();

--- a/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomainConstructor.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IDomainConstructor
 {
 	fflib_IDomain construct(List<Object> objects);

--- a/sfdx-source/apex-common/main/classes/fflib_IDomainFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IDomainFactory.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IDomainFactory
 {
 	fflib_IDomain newInstance(Set<Id> recordIds);

--- a/sfdx-source/apex-common/main/classes/fflib_IObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IObjects.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IObjects extends fflib_IDomain
 {
 	/**

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectDomain.cls
@@ -25,6 +25,7 @@
 **/
 
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_ISObjectDomain extends fflib_IDomain
 {
     /**

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectSelector.cls
@@ -25,6 +25,7 @@
 **/
 
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_ISObjectSelector
 {
 	/**

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjectUnitOfWork.cls
@@ -28,6 +28,7 @@
  * @see fflib_SObjectUnitOfWork
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions, PMD.ExcessiveParameterList')
 public interface fflib_ISObjectUnitOfWork
 {
     /**

--- a/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISObjects.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_ISObjects extends fflib_IObjects
 {
 	/**

--- a/sfdx-source/apex-common/main/classes/fflib_ISelectorFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_ISelectorFactory.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_ISelectorFactory
 {
 	fflib_ISObjectSelector newInstance(SObjectType sObjectType);

--- a/sfdx-source/apex-common/main/classes/fflib_IServiceFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IServiceFactory.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IServiceFactory
 {
 	Object newInstance(Type serviceInterfaceType);

--- a/sfdx-source/apex-common/main/classes/fflib_IUnitOfWorkFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_IUnitOfWorkFactory.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public interface fflib_IUnitOfWorkFactory
 {
 	fflib_ISObjectUnitOfWork newInstance();

--- a/sfdx-source/apex-common/main/classes/fflib_Objects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_Objects.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions')
 public virtual class fflib_Objects implements fflib_IObjects
 {
 	@NamespaceAccessible

--- a/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_QueryFactory.cls
@@ -52,6 +52,7 @@
  * https://docs.google.com/a/financialforce.com/document/d/1I4cxN4xHT4UJj_3Oi0YBL_MJ5chm-KG8kMN1D1un8-g/edit?usp=sharing
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.CognitiveComplexity, PMD.CyclomaticComplexity, PMD.ExcessivePublicCount, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.FieldDeclarationsShouldBeAtStart, PMD.LocalVariableNamingConventions, PMD.ApexDoc, PMD.StdCyclomaticComplexity, PMD.NcssMethodCount, PMD.ExcessiveClassLength')
 public class fflib_QueryFactory { //No explicit sharing declaration - inherit from caller
 	@NamespaceAccessible
 	public enum SortOrder {ASCENDING, DESCENDING}
@@ -462,6 +463,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param related The related object type
 	**/
 	@NamespaceAccessible
+	@SuppressWarnings('PMD.AvoidDebugStatements')
 	public fflib_QueryFactory subselectQuery(SObjectType related){ 
 		System.debug(LoggingLevel.WARN, 'fflib_QueryFactory.subselectQuery(Schema.SObjectType) is deprecated and will be removed in a future release. Use fflib_QueryFactory.subselectQuery(String) or fflib_QueryFactory.subselectQuery(ChildRelationship) instead.');
 		return setSubselectQuery(getChildRelationship(related), false);
@@ -476,6 +478,7 @@ public class fflib_QueryFactory { //No explicit sharing declaration - inherit fr
 	 * @param assertIsAccessible indicates whether to check if the user has access to the subquery object
 	**/
 	@NamespaceAccessible
+	@SuppressWarnings('PMD.AvoidDebugStatements')
 	public fflib_QueryFactory subselectQuery(SObjectType related, Boolean assertIsAccessible){
 		System.debug(LoggingLevel.WARN, 'fflib_QueryFactory.subselectQuery(Schema.SObjectType, Boolean) is deprecated and will be removed in a future release. Use fflib_QueryFactory.subselectQuery(String, Boolean) or fflib_QueryFactory.subselectQuery(ChildRelationship, Boolean) instead.'); 
 		return setSubselectQuery(getChildRelationship(related), assertIsAccessible);

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDescribe.cls
@@ -37,6 +37,7 @@
  * namespace detection logic encapsulated.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ApexDoc, PMD.ClassNamingConventions, PMD.AvoidBooleanMethodParameters, PMD.CognitiveComplexity')
 public class fflib_SObjectDescribe {
 	//internal implementation details
 	private Schema.SObjectType token;

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectDomain.cls
@@ -39,6 +39,7 @@
  *
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.CognitiveComplexity, PMD.CyclomaticComplexity, PMD.ExcessivePublicCount, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.FieldDeclarationsShouldBeAtStart, PMD.LocalVariableNamingConventions, PMD.ApexDoc, PMD.StdCyclomaticComplexity, PMD.NcssMethodCount, PMD.ExcessiveClassLength')
 public virtual with sharing class fflib_SObjectDomain
 		extends fflib_SObjects
 	implements fflib_ISObjectDomain

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectSelector.cls
@@ -28,6 +28,7 @@
  * Class providing common database query support for abstracting and encapsulating query logic
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.FieldDeclarationsShouldBeAtStart, PMD.LocalVariableNamingConventions, PMD.ApexDoc, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.ExcessivePublicCount, PMD.StdCyclomaticComplexity, PMD.NcssMethodCount')
 public abstract with sharing class fflib_SObjectSelector
 	implements fflib_ISObjectSelector
 {

--- a/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjectUnitOfWork.cls
@@ -52,6 +52,7 @@
  *
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.ExcessivePublicCount, PMD.NcssMethodCount, PMD.ExcessiveClassLength')
 public virtual class fflib_SObjectUnitOfWork
     implements fflib_ISObjectUnitOfWork
 {

--- a/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SObjects.cls
@@ -24,6 +24,7 @@
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity')
 public virtual class fflib_SObjects
 		extends fflib_Objects
 		implements fflib_ISObjects

--- a/sfdx-source/apex-common/main/classes/fflib_SecurityUtils.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_SecurityUtils.cls
@@ -29,6 +29,7 @@
  * user does not have the proper security granted.
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.FieldDeclarationsShouldBeAtStart')
 public class fflib_SecurityUtils  
 {
     @TestVisible

--- a/sfdx-source/apex-common/main/classes/fflib_StringBuilder.cls
+++ b/sfdx-source/apex-common/main/classes/fflib_StringBuilder.cls
@@ -30,6 +30,7 @@
  * NOTE: Aspects of this were developed before recent improvements to String handling, as such could likely be enhanced at this stage.
  **/
 @NamespaceAccessible
+@SuppressWarnings('PMD.EmptyStatementBlock, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.FieldNamingConventions, PMD.PropertyNamingConventions, PMD.ApexDoc')
 public virtual class fflib_StringBuilder
 {
 	@NamespaceAccessible

--- a/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_ApplicationTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.FieldNamingConventions, PMD.FieldDeclarationsShouldBeAtStart, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity, PMD.AvoidDeeplyNestedIfStmts, PMD.StdCyclomaticComplexity')
 private class fflib_ApplicationTest 
 {
 	@IsTest

--- a/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_ObjectsTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.PropertyNamingConventions')
 private class fflib_ObjectsTest
 {
 	private static final fflib_ObjectsTest.DataTransferObject TRANSFER_OBJECT_A = new DataTransferObject('Test A');

--- a/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_QueryFactoryTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @isTest( isParallel = true )
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.CyclomaticComplexity, PMD.LocalVariableNamingConventions')
 private class fflib_QueryFactoryTest {
 
 	@isTest

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectDescribeTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectDescribeTest.cls
@@ -29,6 +29,7 @@
 	Used under a BSD license: https://github.com/capeterson/Apex-Util/blob/master/LICENSE
 **/
 @isTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ClassNamingConventions, PMD.MethodNamingConventions')
 private class fflib_SObjectDescribeTest {
 
 	/**

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectDomainTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectDomainTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.NcssCount, PMD.NcssMethodCount')
 private with sharing class fflib_SObjectDomainTest 
 {	
 	@IsTest

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectSelectorTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.CognitiveComplexity')
 private with sharing class fflib_SObjectSelectorTest 
 {
 	@TestSetup

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectUnitOfWorkTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest(IsParallel=true)
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.AvoidBooleanMethodParameters, PMD.ExcessiveParameterList, PMD.CyclomaticComplexity, PMD.EmptyStatementBlock, PMD.FieldNamingConventions, PMD.FieldDeclarationsShouldBeAtStart')
 private with sharing class fflib_SObjectUnitOfWorkTest
 {
     // SObjects (in order of dependency) used by UnitOfWork in tests bellow

--- a/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SObjectsTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ApexDoc, PMD.ClassNamingConventions')
 public class fflib_SObjectsTest
 {
 	private static Integer testFakeIdSequence = 0;

--- a/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_SecurityUtilsTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @isTest @TestVisible
+@SuppressWarnings('PMD.ClassNamingConventions, PMD.MethodNamingConventions, PMD.ExcessiveParameterList')
 private class fflib_SecurityUtilsTest {
 
 	@TestSetup @TestVisible

--- a/sfdx-source/apex-common/test/classes/fflib_StringBuilderTest.cls
+++ b/sfdx-source/apex-common/test/classes/fflib_StringBuilderTest.cls
@@ -25,6 +25,7 @@
 **/
 
 @IsTest
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs, PMD.ClassNamingConventions, PMD.MethodNamingConventions')
 private with sharing class fflib_StringBuilderTest 
 {	
 	static testMethod void testfflib_StringBuilder1()


### PR DESCRIPTION
This PR establishes the initial Code Analyzer baseline discussed in #530, following the approach merged for `fflib-apex-mocks` in [#174](https://github.com/apex-enterprise-patterns/fflib-apex-mocks/pull/174).

It adds documented, top-level `@SuppressWarnings` markers following the policy demonstrated in [jprichter/fflib-apex-common#10](https://github.com/jprichter/fflib-apex-common/pull/10). The change covers 31 production and test classes: single-line PMD suppressions and nothing else.

The before/after `pmd:all` results are included below. The remaining findings are intentionally left visible for follow-up PRs to make targeted behavioral, test-correctness, or mechanical cleanup changes.

# Code Analyzer comparison

Rule selector: `pmd:all`

Before: `origin/master` (`335e6a2589066bed182acbeb11bc1bfaba0070c4`)

After: `feature/code-analyzer-pmd-suppressions` 

| Severity | Severity Level | Rule                                         |   Before |   After |     Delta |
| -------: | -------------- | -------------------------------------------- | -------: | ------: | --------: |
|        2 | High           | ApexUnitTestMethodShouldHaveIsTestAnnotation |       17 |      17 |         0 |
|        2 | High           | EagerlyLoadedDescribeSObjectResult           |       21 |      21 |         0 |
|        2 | High           | EmptyCatchBlock                              |        1 |       1 |         0 |
|        2 | High           | OverrideBothEqualsAndHashcode                |        1 |       1 |         0 |
|        3 | Moderate       | ApexAssertionsShouldIncludeMessage           |      294 |     294 |         0 |
|        3 | Moderate       | ApexSharingViolations                        |        1 |       1 |         0 |
|        3 | Moderate       | ApexUnitTestClassShouldHaveAsserts           |        7 |       7 |         0 |
|        3 | Moderate       | AvoidBooleanMethodParameters                 |       44 |       0 |       -44 |
|        3 | Moderate       | AvoidDeeplyNestedIfStmts                     |        2 |       0 |        -2 |
|        3 | Moderate       | AvoidHardcodingId                            |       13 |      13 |         0 |
|        3 | Moderate       | ClassNamingConventions                       |       31 |       0 |       -31 |
|        3 | Moderate       | CognitiveComplexity                          |       15 |       0 |       -15 |
|        3 | Moderate       | CyclomaticComplexity                         |       16 |       0 |       -16 |
|        3 | Moderate       | EmptyStatementBlock                          |       42 |       0 |       -42 |
|        3 | Moderate       | ExcessiveClassLength                         |        2 |       0 |        -2 |
|        3 | Moderate       | ExcessiveParameterList                       |       20 |       0 |       -20 |
|        3 | Moderate       | ExcessivePublicCount                         |        5 |       0 |        -5 |
|        3 | Moderate       | FieldDeclarationsShouldBeAtStart             |        6 |       0 |        -6 |
|        3 | Moderate       | FieldNamingConventions                       |       54 |       0 |       -54 |
|        3 | Moderate       | ForLoopsMustUseBraces                        |       11 |      11 |         0 |
|        3 | Moderate       | IfElseStmtsMustUseBraces                     |      119 |     119 |         0 |
|        3 | Moderate       | IfStmtsMustUseBraces                         |      117 |     117 |         0 |
|        3 | Moderate       | LocalVariableNamingConventions               |        1 |       0 |        -1 |
|        3 | Moderate       | MethodNamingConventions                      |       62 |       0 |       -62 |
|        3 | Moderate       | NcssCount                                    |        1 |       0 |        -1 |
|        3 | Moderate       | PropertyNamingConventions                    |       19 |       0 |       -19 |
|        3 | Moderate       | StdCyclomaticComplexity                      |       11 |       0 |       -11 |
|        3 | Moderate       | UnusedLocalVariable                          |       11 |      11 |         0 |
|        4 | Low            | AnnotationsNamingConventions                 |       63 |      63 |         0 |
|        4 | Low            | ApexDoc                                      |      516 |       0 |      -516 |
|        4 | Low            | ApexUnitTestClassShouldHaveRunAs             |      162 |       0 |      -162 |
|        4 | Low            | AvoidDebugStatements                         |        8 |       6 |        -2 |
|        4 | Low            | DebugsShouldUseLoggingLevel                  |        4 |       4 |         0 |
|        4 | Low            | NcssMethodCount                              |        6 |       0 |        -6 |
|          |                | **Total**                                    | **1703** | **686** | **-1017** |

Validation: Salesforce Code Analyzer run with `--rule-selector pmd:all`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/fflib-apex-common/533)
<!-- Reviewable:end -->
